### PR TITLE
Add ASCII banner at startup

### DIFF
--- a/src/main/java/net/cg4j/Banner.java
+++ b/src/main/java/net/cg4j/Banner.java
@@ -1,0 +1,83 @@
+package net.cg4j;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Displays the CG4j ASCII art banner with version information at startup.
+ */
+public class Banner {
+
+  private static final Logger logger = LogManager.getLogger(Banner.class);
+
+  private static final String TAGLINE = "CG4j: Call Graph Generation for Java";
+
+  private static final String[] LOGO_LINES = {
+      "   ______________ __  _ ",
+      "  / ____/ ____/ // / (_)",
+      " / /   / / __/ // /_/ / ",
+      "/ /___/ /_/ /__  __/ /  ",
+      "\\____/\\____/  /_/_/ /   ",
+      "               /___/    "
+  };
+
+  private static final int LOGO_WIDTH = LOGO_LINES[0].length();
+
+  private Banner() {
+    // Utility class
+  }
+
+  /**
+   * Prints the ASCII art banner with version information to the logger.
+   */
+  public static void print() {
+    for (String line : buildBannerLines()) {
+      logger.info("{}", line);
+    }
+  }
+
+  /**
+   * Builds the full banner as a list of lines. Package-private for testing.
+   */
+  static List<String> buildBannerLines() {
+    String version = Version.getInstance().getFullVersion();
+
+    // Box inner width: tagline + 4 chars padding (2 each side)
+    int boxInnerWidth = TAGLINE.length() + 4;
+    int boxOuterWidth = boxInnerWidth + 2;
+    String border = "+" + "-".repeat(boxInnerWidth) + "+";
+
+    // Center logo lines over the box
+    int logoPadding = Math.max(0, (boxOuterWidth - LOGO_WIDTH) / 2);
+    String logoIndent = " ".repeat(logoPadding);
+
+    List<String> lines = new ArrayList<>();
+    lines.add("");
+    for (String line : LOGO_LINES) {
+      lines.add(logoIndent + line);
+    }
+    lines.add(border);
+    lines.add("|" + centerText(TAGLINE, boxInnerWidth) + "|");
+    lines.add("|" + centerText(version, boxInnerWidth) + "|");
+    lines.add(border);
+    lines.add("");
+
+    return lines;
+  }
+
+  /**
+   * Centers text within a given width, padding with spaces.
+   */
+  private static String centerText(String text, int width) {
+    if (text.length() >= width) {
+      return text;
+    }
+    int totalPadding = width - text.length();
+    int leftPadding = totalPadding / 2;
+    int rightPadding = totalPadding - leftPadding;
+    return " ".repeat(leftPadding) + text + " ".repeat(rightPadding);
+  }
+}

--- a/src/main/java/net/cg4j/Main.java
+++ b/src/main/java/net/cg4j/Main.java
@@ -72,6 +72,8 @@ public class Main implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
+    Banner.print();
+
     // Validate target JAR exists
     if (!targetJar.exists()) {
       logger.error("Target JAR file not found: {}", targetJar);

--- a/src/test/java/net/cg4j/BannerTest.java
+++ b/src/test/java/net/cg4j/BannerTest.java
@@ -1,0 +1,66 @@
+package net.cg4j;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class BannerTest {
+
+  /**
+   * Unit test: Verifies Banner.print() completes without throwing any exception.
+   */
+  @Test
+  void testPrint_DoesNotThrow() {
+    assertThatNoException().isThrownBy(Banner::print);
+  }
+
+  /**
+   * Unit test: Verifies the banner contains the CG4j tagline.
+   */
+  @Test
+  void testBuildBannerLines_ContainsTagline() {
+    List<String> lines = Banner.buildBannerLines();
+
+    String output = String.join("\n", lines);
+    assertThat(output).contains("CG4j: Call Graph Generation for Java");
+  }
+
+  /**
+   * Unit test: Verifies the banner contains version information.
+   */
+  @Test
+  void testBuildBannerLines_ContainsVersion() {
+    List<String> lines = Banner.buildBannerLines();
+
+    String output = String.join("\n", lines);
+    String version = Version.getInstance().getFullVersion();
+    assertThat(output).contains(version);
+  }
+
+  /**
+   * Unit test: Verifies the banner contains the ASCII art logo.
+   */
+  @Test
+  void testBuildBannerLines_ContainsLogo() {
+    List<String> lines = Banner.buildBannerLines();
+
+    String output = String.join("\n", lines);
+    assertThat(output).contains("/ ____/ ____/");
+    assertThat(output).contains("/___/");
+  }
+
+  /**
+   * Unit test: Verifies the banner contains the dashed box border.
+   */
+  @Test
+  void testBuildBannerLines_ContainsBox() {
+    List<String> lines = Banner.buildBannerLines();
+
+    String output = String.join("\n", lines);
+    assertThat(output).contains("+--");
+    assertThat(output).contains("--+");
+  }
+}


### PR DESCRIPTION
## Summary

Adds a FIGlet Slant-style ASCII art banner that displays at the beginning of every call graph generation run. The banner shows the CG4j logo, project tagline, and dynamic version (including commit hash for SNAPSHOT builds) inside a centered dashed box.

## Changes

- Add `Banner.java` utility class with ASCII art logo, centered info box, and dynamic version from `Version.getInstance()`
- Hook `Banner.print()` as the first call in `Main.call()` so the banner appears on every run but not on `--help`/`--version`
- Add `BannerTest.java` with 5 unit tests covering tagline, version, logo art, and box rendering