### PR TITLE
Add X social link to MkDocs footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,9 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/cg4j/cg4j
       name: CG4j on GitHub
+    - icon: fontawesome/brands/x-twitter
+      link: https://x.com/cg4j_net
+      name: CG4j on X
 
 extra_css:
   - css/extra.css


### PR DESCRIPTION
## Summary
Adds the project's X (Twitter) account to the MkDocs Material footer social links. The icon appears alongside the existing GitHub link in the site footer.

## Changes
- Add `fontawesome/brands/x-twitter` icon to `mkdocs.yml` social links
- Link points to https://x.com/cg4j_net with accessible name "CG4j on X"