### PR TITLE
Add README badges for project status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add README badges for license, build status, and Maven release visibility (#43)
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 # CG4j - Call Graph Generation for Java
 
 <p align="center">
-  <a href="https://github.com/cg4j/cg4j/actions/workflows/build.yml" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/github/actions/workflow/status/cg4j/cg4j/build.yml?branch=master&label=build&style=flat-square" alt="Build"></a>
-  <a href="https://github.com/cg4j/cg4j/blob/master/LICENSE" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/github/license/cg4j/cg4j?style=flat-square" alt="License"></a>
-  <a href="https://mvnrepository.com/artifact/net.cg4j/cg4j" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
+  <a href="https://github.com/cg4j/cg4j/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/cg4j/cg4j/build.yml?branch=master&label=build&style=flat-square" alt="Build"></a>
+  <a href="https://github.com/cg4j/cg4j/blob/master/LICENSE"><img src="https://img.shields.io/github/license/cg4j/cg4j?style=flat-square" alt="License"></a>
+  <a href="https://mvnrepository.com/artifact/net.cg4j/cg4j"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
 </p>
 
 A command-line tool to build call graphs for Java programs.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/cg4j/cg4j/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/cg4j/cg4j/build.yml?branch=master&label=build&style=flat-square" alt="Build"></a>
   <a href="https://github.com/cg4j/cg4j/blob/master/LICENSE"><img src="https://img.shields.io/github/license/cg4j/cg4j?style=flat-square" alt="License"></a>
-  <a href="https://mvnrepository.com/artifact/net.cg4j/cg4j"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
+  <a href="https://central.sonatype.com/artifact/net.cg4j/cg4j"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
 </p>
 
 A command-line tool to build call graphs for Java programs.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 # CG4j - Call Graph Generation for Java
 
 <p align="center">
-  <a href="https://github.com/cg4j/cg4j/blob/master/LICENSE"><img src="https://img.shields.io/github/license/cg4j/cg4j?style=flat-square" alt="License"></a>
-  <a href="https://github.com/cg4j/cg4j/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/cg4j/cg4j/build.yml?branch=master&label=build&style=flat-square" alt="Build"></a>
-  <a href="https://mvnrepository.com/artifact/net.cg4j/cg4j"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
+  <a href="https://github.com/cg4j/cg4j/actions/workflows/build.yml" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/github/actions/workflow/status/cg4j/cg4j/build.yml?branch=master&label=build&style=flat-square" alt="Build"></a>
+  <a href="https://github.com/cg4j/cg4j/blob/master/LICENSE" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/github/license/cg4j/cg4j?style=flat-square" alt="License"></a>
+  <a href="https://mvnrepository.com/artifact/net.cg4j/cg4j" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
 </p>
 
 A command-line tool to build call graphs for Java programs.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # CG4j - Call Graph Generation for Java
 
+<p align="center">
+  <a href="https://github.com/cg4j/cg4j/blob/master/LICENSE"><img src="https://img.shields.io/github/license/cg4j/cg4j?style=flat-square" alt="License"></a>
+  <a href="https://github.com/cg4j/cg4j/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/cg4j/cg4j/build.yml?branch=master&label=build&style=flat-square" alt="Build"></a>
+  <a href="https://mvnrepository.com/artifact/net.cg4j/cg4j"><img src="https://img.shields.io/maven-central/v/net.cg4j/cg4j?label=maven&style=flat-square" alt="Maven"></a>
+</p>
+
 A command-line tool to build call graphs for Java programs.
 
 ## Table of Contents
@@ -122,7 +128,7 @@ Or using Maven directly:
 mvn clean package
 ```
 
-This creates `target/cg4j-0.1.0-SNAPSHOT-jar-with-dependencies.jar`
+This creates `target/cg4j-<version>-jar-with-dependencies.jar`
 
 Install cg4j from the local source tree:
 


### PR DESCRIPTION
## Summary
This updates the README top section so the repository surfaces its key trust signals immediately. It adds badges for the project license, GitHub build status, and published Maven artifact, and it also removes a stale hardcoded jar version example.

## Changes
- add a centered badge row below the main README title
- link badges to the license, build workflow, and Maven package page
- use a Maven Central version badge for the published `net.cg4j:cg4j` artifact
- replace the hardcoded jar filename example with a version placeholder