### PR TITLE
Add Google Java formatting with Spotless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,24 +12,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: maven
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
 
-    - name: Install pre-commit
-      run: pip install --upgrade pre-commit
+      - name: Install pre-commit
+        run: pip install --upgrade pre-commit
 
-    - name: Run pre-commit
-      run: pre-commit run --all-files
+      - name: Run pre-commit
+        run: pre-commit run --all-files
 
   compile:
     name: Compile (Java ${{ matrix.java }})
@@ -41,27 +41,27 @@ jobs:
         java: ['11', '21']
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ matrix.java }}
-        distribution: 'temurin'
-        cache: maven
-    
-    - name: Compile with Maven
-      run: mvn clean compile
-    
-    - name: Upload compiled classes
-      uses: actions/upload-artifact@v4
-      with:
-        name: compiled-classes-java-${{ matrix.java }}
-        path: |
-          target/classes/
-          target/generated-sources/
-          target/maven-status/
-        retention-days: 1
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Compile with Maven
+        run: mvn clean compile
+
+      - name: Upload compiled classes
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-classes-java-${{ matrix.java }}
+          path: |
+            target/classes/
+            target/generated-sources/
+            target/maven-status/
+          retention-days: 1
 
   test:
     name: Test
@@ -69,20 +69,20 @@ jobs:
     needs: compile
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: maven
-    
-    - name: Download compiled classes
-      uses: actions/download-artifact@v4
-      with:
-        name: compiled-classes-java-21
-        path: target/
-    
-    - name: Run tests
-      run: mvn test
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Download compiled classes
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-classes-java-21
+          path: target/
+
+      - name: Run tests
+        run: mvn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,35 @@ on:
     branches: [ master ]
 
 jobs:
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+
+    - name: Install pre-commit
+      run: pip install --upgrade pre-commit
+
+    - name: Run pre-commit
+      run: pre-commit run --all-files
+
   compile:
     name: Compile (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
-    
+    needs: pre-commit
+
     strategy:
       matrix:
         java: ['11', '21']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: spotless-check
+        name: spotless-check
+        entry: mvn spotless:check
+        language: system
+        pass_filenames: false
+        types: [java]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,7 @@ mvn clean test jacoco:report
 
 ### Import Organization
 
-1. Group imports in this order with blank lines between:
-   - Third-party libraries (WALA, Picocli, Log4j) - alphabetically sorted
-   - Java standard library - alphabetically sorted
+1. Let Spotless with Google Java Format manage import ordering and whitespace
 2. No wildcard imports (`import java.util.*;`) - use explicit imports only
 3. No unused imports
 4. No fully qualified class names in code — always import the class and use its simple name
@@ -63,6 +61,8 @@ mvn clean test jacoco:report
 
 ### Formatting
 
+- **Formatter**: Google Java Format via `mvn spotless:apply`
+- **Verification**: `mvn spotless:check`
 - **Indentation**: 2 spaces (no tabs)
 - **Line length**: ~100 characters (flexible for readability)
 - **Braces**: K&R style - opening brace on same line
@@ -184,10 +184,10 @@ When adding dependencies:
 ## Don'ts
 
 - ❌ Don't use wildcard imports
-- ❌ Don't use tabs (use 2 spaces)
+- ❌ Don't use tabs for indentation
 - ❌ Don't catch exceptions unnecessarily
 - ❌ Don't use abbreviations in names (except standard: `cg`, `csv`)
-- ❌ Don't modify existing formatting style
+- ❌ Don't hand-format Java files against Spotless output
 - ❌ Don't add null-assertion libraries
 - ❌ Don't use `TODO` comments without tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adopt Google Java formatting with Spotless and pre-commit ([#50](https://github.com/cg4j/cg4j/pull/50))
+- Adopt Google Java formatting with Spotless, pre-commit, and CI checks ([#50](https://github.com/cg4j/cg4j/pull/50))
 - Add README badges for license, build status, and Maven release visibility (#43)
 - Use lowercase `-v` as the CLI version flag (with `--version`) (#44)
 - Improve public API Javadocs so release builds complete without warnings ([#49](https://github.com/cg4j/cg4j/pull/49))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Adopt Google Java formatting with Spotless and pre-commit ([#50](https://github.com/cg4j/cg4j/pull/50))
 - Add README badges for license, build status, and Maven release visibility (#43)
 - Use lowercase `-v` as the CLI version flag (with `--version`) (#44)
 - Improve public API Javadocs so release builds complete without warnings ([#49](https://github.com/cg4j/cg4j/pull/49))

--- a/README.md
+++ b/README.md
@@ -170,6 +170,27 @@ grep -oP '<tfoot>.*?<td class="ctr2">\K[0-9]+%' target/site/jacoco/index.html | 
 
 Test data: `src/test/resources/test-jars/`
 
+### Formatting
+
+Format and verify Java sources with Spotless:
+
+```bash
+# Check formatting
+mvn spotless:check
+
+# Apply Google Java Format to Java sources
+mvn spotless:apply
+```
+
+Install the local pre-commit hook:
+
+```bash
+pipx install pre-commit
+pre-commit install
+```
+
+The configured hook runs `mvn spotless:check` before each commit.
+
 ## Output Format
 
 CSV file with two columns:

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,16 @@
                 <version>3.14.1</version>
             </plugin>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat />
+                    </java>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.1</version>

--- a/src/main/java/net/cg4j/Banner.java
+++ b/src/main/java/net/cg4j/Banner.java
@@ -1,14 +1,11 @@
 package net.cg4j;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Displays the CG4j ASCII art banner with version information at startup.
- */
+/** Displays the CG4j ASCII art banner with version information at startup. */
 public class Banner {
 
   private static final Logger logger = LogManager.getLogger(Banner.class);
@@ -16,12 +13,12 @@ public class Banner {
   private static final String TAGLINE = "CG4j: Call Graph Generation for Java";
 
   private static final String[] LOGO_LINES = {
-      "   ______________ __  _ ",
-      "  / ____/ ____/ // / (_)",
-      " / /   / / __/ // /_/ / ",
-      "/ /___/ /_/ /__  __/ /  ",
-      "\\____/\\____/  /_/_/ /   ",
-      "               /___/    "
+    "   ______________ __  _ ",
+    "  / ____/ ____/ // / (_)",
+    " / /   / / __/ // /_/ / ",
+    "/ /___/ /_/ /__  __/ /  ",
+    "\\____/\\____/  /_/_/ /   ",
+    "               /___/    "
   };
 
   private static final int LOGO_WIDTH = LOGO_LINES[0].length();
@@ -30,18 +27,14 @@ public class Banner {
     // Utility class
   }
 
-  /**
-   * Prints the ASCII art banner with version information to the logger.
-   */
+  /** Prints the ASCII art banner with version information to the logger. */
   public static void print() {
     for (String line : buildBannerLines()) {
       logger.info("{}", line);
     }
   }
 
-  /**
-   * Builds the full banner as a list of lines. Package-private for testing.
-   */
+  /** Builds the full banner as a list of lines. Package-private for testing. */
   static List<String> buildBannerLines() {
     String version = Version.getInstance().getFullVersion();
 
@@ -68,9 +61,7 @@ public class Banner {
     return lines;
   }
 
-  /**
-   * Centers text within a given width, padding with spaces.
-   */
+  /** Centers text within a given width, padding with spaces. */
   private static String centerText(String text, int width) {
     if (text.length() >= width) {
       return text;

--- a/src/main/java/net/cg4j/Main.java
+++ b/src/main/java/net/cg4j/Main.java
@@ -1,19 +1,6 @@
 package net.cg4j;
 
 import com.ibm.wala.ipa.callgraph.CallGraph;
-import net.cg4j.asm.AsmCallGraphBuilder;
-import net.cg4j.asm.CallGraphResult;
-import net.cg4j.asm.ScopeExclusions;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.impl.Log4jContextFactory;
-import org.apache.logging.log4j.core.selector.ContextSelector;
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -27,63 +14,85 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import net.cg4j.asm.AsmCallGraphBuilder;
+import net.cg4j.asm.CallGraphResult;
+import net.cg4j.asm.ScopeExclusions;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.impl.Log4jContextFactory;
+import org.apache.logging.log4j.core.selector.ContextSelector;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
-/**
- * Main entry point for the call graph generation tool.
- */
-@Command(name = "cg4j",
-         mixinStandardHelpOptions = false,
-         versionProvider = VersionProvider.class,
-         description = "Builds call graphs from Java JAR files using WALA or ASM")
+/** Main entry point for the call graph generation tool. */
+@Command(
+    name = "cg4j",
+    mixinStandardHelpOptions = false,
+    versionProvider = VersionProvider.class,
+    description = "Builds call graphs from Java JAR files using WALA or ASM")
 public class Main implements Callable<Integer> {
 
   private static final Logger logger = LogManager.getLogger(Main.class);
 
-  @Option(names = {"-h", "--help"}, usageHelp = true,
-          description = "Show this help message and exit")
+  @Option(
+      names = {"-h", "--help"},
+      usageHelp = true,
+      description = "Show this help message and exit")
   private boolean helpRequested;
 
-  @Option(names = {"-v", "--version"}, versionHelp = true,
-          description = "Print version information and exit")
+  @Option(
+      names = {"-v", "--version"},
+      versionHelp = true,
+      description = "Print version information and exit")
   private boolean versionRequested;
 
-  @Option(names = {"-j", "--app-jar"},
-          required = true,
-          description = "JAR file to analyze")
+  @Option(
+      names = {"-j", "--app-jar"},
+      required = true,
+      description = "JAR file to analyze")
   private File targetJar;
 
-  @Option(names = {"-o", "--output"}, 
-          description = "Output CSV file (default: ${DEFAULT-VALUE})",
-          defaultValue = "callgraph.csv")
+  @Option(
+      names = {"-o", "--output"},
+      description = "Output CSV file (default: ${DEFAULT-VALUE})",
+      defaultValue = "callgraph.csv")
   private String outputCsv;
 
-  @Option(names = {"-d", "--deps"}, 
-          description = "Directory containing dependency JAR files")
+  @Option(
+      names = {"-d", "--deps"},
+      description = "Directory containing dependency JAR files")
   private File depsDir;
 
-  @Option(names = {"--include-rt"},
-          description = "Include Java Runtime (RT) jar in call graph analysis (default: ${DEFAULT-VALUE})",
-          defaultValue = "true")
+  @Option(
+      names = {"--include-rt"},
+      description =
+          "Include Java Runtime (RT) jar in call graph analysis (default: ${DEFAULT-VALUE})",
+      defaultValue = "true")
   private boolean includeRt;
 
-  @Option(names = {"--engine"},
-          description = "Call graph engine: wala or asm (default: ${DEFAULT-VALUE})",
-          defaultValue = "wala")
+  @Option(
+      names = {"--engine"},
+      description = "Call graph engine: wala or asm (default: ${DEFAULT-VALUE})",
+      defaultValue = "wala")
   private String engine;
 
-  @Option(names = {"--exclusions"},
-          description = "Exclusion patterns file for ASM engine scope "
+  @Option(
+      names = {"--exclusions"},
+      description =
+          "Exclusion patterns file for ASM engine scope "
               + "(default: built-in WALA-compatible exclusions)")
   private File exclusionsFile;
 
   /** Suppresses info/progress logs, showing only errors. */
-  @Option(names = {"-q", "--quiet"},
-          description = "Suppress info/progress logs (errors only)")
+  @Option(
+      names = {"-q", "--quiet"},
+      description = "Suppress info/progress logs (errors only)")
   private boolean quiet;
 
-  /**
-   * Creates the CLI entry point.
-   */
+  /** Creates the CLI entry point. */
   public Main() {}
 
   /**
@@ -143,16 +152,15 @@ public class Main implements Callable<Integer> {
     return 0;
   }
 
-  /**
-   * Builds call graph using WALA engine.
-   */
+  /** Builds call graph using WALA engine. */
   private int buildWithWala(List<File> dependencies) throws Exception {
     // Create exclusion file
     Path exclusionFile = createExclusionFile();
     logger.info("Created exclusion file: {}", exclusionFile);
 
     WalaCallGraphBuilder builder = new WalaCallGraphBuilder();
-    CallGraph cg = builder.buildCallGraph(targetJar.getPath(), dependencies, exclusionFile.toFile());
+    CallGraph cg =
+        builder.buildCallGraph(targetJar.getPath(), dependencies, exclusionFile.toFile());
     logger.info("Total nodes: {}", cg.getNumberOfNodes());
 
     // Write call graph to CSV
@@ -160,9 +168,7 @@ public class Main implements Callable<Integer> {
     return writeCallGraphToCSV(cg, outputCsv, includeRt);
   }
 
-  /**
-   * Builds call graph using ASM engine.
-   */
+  /** Builds call graph using ASM engine. */
   private int buildWithAsm(List<File> dependencies) throws Exception {
     // Load exclusions
     ScopeExclusions exclusions;
@@ -175,8 +181,8 @@ public class Main implements Callable<Integer> {
     }
 
     AsmCallGraphBuilder builder = new AsmCallGraphBuilder();
-    CallGraphResult result = builder.buildCallGraph(
-        targetJar.getPath(), dependencies, includeRt, exclusions);
+    CallGraphResult result =
+        builder.buildCallGraph(targetJar.getPath(), dependencies, includeRt, exclusions);
     logger.info("Total reachable methods: {}", result.getReachableMethods().size());
 
     // Write call graph to CSV
@@ -184,21 +190,16 @@ public class Main implements Callable<Integer> {
     return writeAsmCallGraphToCSV(result, outputCsv);
   }
 
-  /**
-   * Sets all Log4j2 logger contexts to ERROR level for quiet mode.
-   */
+  /** Sets all Log4j2 logger contexts to ERROR level for quiet mode. */
   private static void setQuietLogging() {
-    ContextSelector selector =
-        ((Log4jContextFactory) LogManager.getFactory()).getSelector();
+    ContextSelector selector = ((Log4jContextFactory) LogManager.getFactory()).getSelector();
     for (LoggerContext context : selector.getLoggerContexts()) {
       context.getConfiguration().getRootLogger().setLevel(Level.ERROR);
       context.updateLoggers();
     }
   }
 
-  /**
-   * Writes ASM call graph result to CSV file.
-   */
+  /** Writes ASM call graph result to CSV file. */
   private static int writeAsmCallGraphToCSV(CallGraphResult result, String outputFile)
       throws IOException {
     try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile))) {
@@ -216,57 +217,56 @@ public class Main implements Callable<Integer> {
 
   /**
    * Writes call graph to CSV file with format: source_method,target_method
-   * 
+   *
    * @param includeRt if false, filters out edges involving RT (Primordial) methods
    */
-  private static int writeCallGraphToCSV(CallGraph cg, String outputFile, boolean includeRt) throws IOException {
+  private static int writeCallGraphToCSV(CallGraph cg, String outputFile, boolean includeRt)
+      throws IOException {
     int edgeCount = 0;
-    
+
     try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile))) {
       writer.println("source_method,target_method");
-      
+
       AtomicInteger edgeCounter = new AtomicInteger(0);
-      Stream<WalaCallGraphBuilder.CallGraphEdge> edges = WalaCallGraphBuilder.extractEdgesAsStream(cg, includeRt);
-      edges.forEach(edge -> {
-        writer.println(edge.source + "," + edge.target);
-        edgeCounter.incrementAndGet();
-      });
+      Stream<WalaCallGraphBuilder.CallGraphEdge> edges =
+          WalaCallGraphBuilder.extractEdgesAsStream(cg, includeRt);
+      edges.forEach(
+          edge -> {
+            writer.println(edge.source + "," + edge.target);
+            edgeCounter.incrementAndGet();
+          });
       edgeCount = edgeCounter.get();
     }
-    
+
     return edgeCount;
   }
 
-  /**
-   * Creates a WALA exclusion file to filter standard library classes.
-   */
+  /** Creates a WALA exclusion file to filter standard library classes. */
   private static Path createExclusionFile() throws IOException {
-    List<String> exclusions = Arrays.asList(
-        "java/util/.*",
-        "java/io/.*",
-        "java/nio/.*",
-        "java/net/.*",
-        "java/math/.*",
-        "java/awt/.*",
-        "java/text/.*",
-        "java/sql/.*",
-        "java/security/.*",
-        "java/time/.*",
-        "javax/.*",
-        "sun/.*",
-        "com/sun/.*",
-        "jdk/.*",
-        "org/graalvm/.*"
-    );
-    
+    List<String> exclusions =
+        Arrays.asList(
+            "java/util/.*",
+            "java/io/.*",
+            "java/nio/.*",
+            "java/net/.*",
+            "java/math/.*",
+            "java/awt/.*",
+            "java/text/.*",
+            "java/sql/.*",
+            "java/security/.*",
+            "java/time/.*",
+            "javax/.*",
+            "sun/.*",
+            "com/sun/.*",
+            "jdk/.*",
+            "org/graalvm/.*");
+
     Path tmpFile = Paths.get("/tmp/wala_exclusions.txt");
     Files.write(tmpFile, exclusions);
     return tmpFile;
   }
 
-  /**
-   * Finds all JAR files in a directory.
-   */
+  /** Finds all JAR files in a directory. */
   private static List<File> findJarsInDirectory(File directory) {
     List<File> jarFiles = new ArrayList<>();
     File[] files = directory.listFiles();
@@ -279,5 +279,4 @@ public class Main implements Callable<Integer> {
     }
     return jarFiles;
   }
-
 }

--- a/src/main/java/net/cg4j/Version.java
+++ b/src/main/java/net/cg4j/Version.java
@@ -4,9 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-/**
- * Version information utility that loads version and git commit hash from properties file.
- */
+/** Version information utility that loads version and git commit hash from properties file. */
 public class Version {
 
   private static final String VERSION_PROPERTIES = "/version.properties";
@@ -17,9 +15,7 @@ public class Version {
 
   private static Version instance;
 
-  /**
-   * Private constructor loads version properties from classpath.
-   */
+  /** Private constructor loads version properties from classpath. */
   private Version() {
     Properties props = new Properties();
     try (InputStream input = Version.class.getResourceAsStream(VERSION_PROPERTIES)) {
@@ -48,7 +44,7 @@ public class Version {
 
   /**
    * Returns the full version string including git commit hash for SNAPSHOT versions.
-   * 
+   *
    * @return formatted version string (e.g., "0.1.0-SNAPSHOT (abc1234)" or "0.1.0")
    */
   public String getFullVersion() {

--- a/src/main/java/net/cg4j/VersionProvider.java
+++ b/src/main/java/net/cg4j/VersionProvider.java
@@ -2,18 +2,14 @@ package net.cg4j;
 
 import picocli.CommandLine.IVersionProvider;
 
-/**
- * Picocli version provider that returns the full version string with git commit hash.
- */
+/** Picocli version provider that returns the full version string with git commit hash. */
 public class VersionProvider implements IVersionProvider {
 
-  /**
-   * Creates the version provider.
-   */
+  /** Creates the version provider. */
   public VersionProvider() {}
 
   @Override
   public String[] getVersion() {
-    return new String[] { Version.getInstance().getFullVersion() };
+    return new String[] {Version.getInstance().getFullVersion()};
   }
 }

--- a/src/main/java/net/cg4j/WalaCallGraphBuilder.java
+++ b/src/main/java/net/cg4j/WalaCallGraphBuilder.java
@@ -19,10 +19,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
-import com.ibm.wala.util.config.FileOfClasses;
-
 import java.io.File;
-import java.io.FileInputStream;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -32,14 +29,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-/**
- * Builds call graphs using WALA with RTA-based analysis.
- */
+/** Builds call graphs using WALA with RTA-based analysis. */
 public class WalaCallGraphBuilder {
 
-  /**
-   * Creates a WALA-backed call graph builder.
-   */
+  /** Creates a WALA-backed call graph builder. */
   public WalaCallGraphBuilder() {}
 
   /**
@@ -51,59 +44,55 @@ public class WalaCallGraphBuilder {
    * @return the constructed WALA call graph
    * @throws Exception if scope creation or call graph construction fails
    */
-  public CallGraph buildCallGraph(String jarFile, List<File> dependencies, File exclusionFile) 
+  public CallGraph buildCallGraph(String jarFile, List<File> dependencies, File exclusionFile)
       throws Exception {
-    
+
     // Build Class Hierarchy with CHA
     ClassHierarchy cha = constructCHA(jarFile, dependencies, exclusionFile);
-    
+
     // Generate entry points (only application and extension classes, never Primordial)
     List<Entrypoint> entrypoints = generateEntryPoints(cha);
-    
+
     if (entrypoints.isEmpty()) {
       throw new RuntimeException("No entry points found in JAR file");
     }
-    
+
     // Configure analysis options
     AnalysisOptions options = new AnalysisOptions();
     options.setEntrypoints(entrypoints);
     options.setReflectionOptions(AnalysisOptions.ReflectionOptions.NONE);
-    
+
     // Build RTA call graph
     AnalysisCacheImpl cache = new AnalysisCacheImpl();
-    CallGraphBuilder<InstanceKey> cgBuilder =
-        Util.makeRTABuilder(options, cache, cha);
-    
+    CallGraphBuilder<InstanceKey> cgBuilder = Util.makeRTABuilder(options, cache, cha);
+
     return cgBuilder.makeCallGraph(options, null);
   }
 
   /**
    * Constructs Class Hierarchy with exclusions.
-   * 
-   * Scope organization:
-   * - Primordial: rt.jar (Java runtime) - always loaded for class hierarchy
-   * - Extension: dependency JARs
-   * - Application: target JAR being analyzed
+   *
+   * <p>Scope organization: - Primordial: rt.jar (Java runtime) - always loaded for class hierarchy
+   * - Extension: dependency JARs - Application: target JAR being analyzed
    */
-  private ClassHierarchy constructCHA(String programJarFile, 
-                                      List<File> dependenciesJarFiles,
-                                      File exclusionFile) throws Exception {
+  private ClassHierarchy constructCHA(
+      String programJarFile, List<File> dependenciesJarFiles, File exclusionFile) throws Exception {
     // Always use standard scope with Primordial (rt.jar), Extension, and Application loaders
     // RT jar is required for class hierarchy construction (java.lang.Object, etc.)
-    AnalysisScope scope = AnalysisScopeReader.instance.makeJavaBinaryAnalysisScope(
-        programJarFile, exclusionFile);
-    
+    AnalysisScope scope =
+        AnalysisScopeReader.instance.makeJavaBinaryAnalysisScope(programJarFile, exclusionFile);
+
     // Add dependency JARs to Extension class loader
     for (File depJarFile : dependenciesJarFiles) {
       scope.addToScope(ClassLoaderReference.Extension, new JarFile(depJarFile));
     }
-    
+
     return ClassHierarchyFactory.make(scope);
   }
 
   /**
-   * Generates entry points from all public methods in application classes only.
-   * Only includes Application loader, not Extension or Primordial.
+   * Generates entry points from all public methods in application classes only. Only includes
+   * Application loader, not Extension or Primordial.
    */
   private List<Entrypoint> generateEntryPoints(IClassHierarchy cha) {
     return StreamSupport.stream(cha.spliterator(), false)
@@ -114,27 +103,19 @@ public class WalaCallGraphBuilder {
         .collect(Collectors.toList());
   }
 
-  /**
-   * Checks if a class is public and from Application loader only.
-   */
+  /** Checks if a class is public and from Application loader only. */
   private boolean isPublicClass(IClass klass) {
-    return isApplicationLoader(klass)
-        && !klass.isInterface()
-        && klass.isPublic();
+    return isApplicationLoader(klass) && !klass.isInterface() && klass.isPublic();
   }
 
-  /**
-   * Checks if a method is public and non-abstract from Application loader.
-   */
+  /** Checks if a method is public and non-abstract from Application loader. */
   private boolean isPublicMethod(IMethod method) {
     return isApplicationLoader(method.getDeclaringClass())
         && method.isPublic()
         && !method.isAbstract();
   }
 
-  /**
-   * Checks if class is from Application loader only.
-   */
+  /** Checks if class is from Application loader only. */
   private boolean isApplicationLoader(IClass klass) {
     ClassLoaderReference ref = klass.getClassLoader().getReference();
     return ref.equals(ClassLoaderReference.Application);
@@ -152,110 +133,106 @@ public class WalaCallGraphBuilder {
     String className = type.getClassName().toString();
     String methodName = selector.getName().toString();
     String descriptor = selector.getDescriptor().toString();
-    
+
     String qualifiedClassName = packageName + className;
-    
+
     // Skip lambda metafactory
     if (qualifiedClassName.equals("java/lang/invoke/LambdaMetafactory")) {
       return null;
     }
-    
+
     return qualifiedClassName + "." + methodName + ":" + descriptor;
   }
 
-  /**
-   * Checks if target URI should be skipped (null or fake clinit).
-   */
+  /** Checks if target URI should be skipped (null or fake clinit). */
   private static boolean shouldSkipTarget(String targetUri) {
-    return targetUri == null || 
-           targetUri.equals("com/ibm/wala/FakeRootClass.fakeWorldClinit:()V");
+    return targetUri == null || targetUri.equals("com/ibm/wala/FakeRootClass.fakeWorldClinit:()V");
   }
 
-  /**
-   * Normalizes source URI, converting fake root methods to <boot>.
-   */
+  /** Normalizes source URI, converting fake root methods to <boot>. */
   private static String normalizeSourceUri(String sourceUri) {
-    if (sourceUri.equals("com/ibm/wala/FakeRootClass.fakeRootMethod:()V") ||
-        sourceUri.equals("com/ibm/wala/FakeRootClass.fakeWorldClinit:()V")) {
+    if (sourceUri.equals("com/ibm/wala/FakeRootClass.fakeRootMethod:()V")
+        || sourceUri.equals("com/ibm/wala/FakeRootClass.fakeWorldClinit:()V")) {
       return "<boot>";
     }
     return sourceUri;
   }
 
-  /**
-   * Checks if edge should be filtered based on RT (Primordial) loader.
-   */
-  private static boolean shouldFilterRtEdge(IMethod sourceMethod, IMethod targetMethod, boolean includeRt) {
+  /** Checks if edge should be filtered based on RT (Primordial) loader. */
+  private static boolean shouldFilterRtEdge(
+      IMethod sourceMethod, IMethod targetMethod, boolean includeRt) {
     if (includeRt) {
       return false; // Don't filter anything
     }
-    
-    ClassLoaderReference sourceLoader = sourceMethod.getDeclaringClass().getClassLoader().getReference();
-    ClassLoaderReference targetLoader = targetMethod.getDeclaringClass().getClassLoader().getReference();
-    
+
+    ClassLoaderReference sourceLoader =
+        sourceMethod.getDeclaringClass().getClassLoader().getReference();
+    ClassLoaderReference targetLoader =
+        targetMethod.getDeclaringClass().getClassLoader().getReference();
+
     boolean sourceIsPrimordial = sourceLoader.equals(ClassLoaderReference.Primordial);
     boolean targetIsPrimordial = targetLoader.equals(ClassLoaderReference.Primordial);
-    
+
     // Filter out if either source or target is Primordial
     return sourceIsPrimordial || targetIsPrimordial;
   }
 
   /**
    * Extracts call graph edges as a stream for processing.
-   * 
+   *
    * @param cg Call graph to extract edges from
    * @param includeRt if false, filters out edges where source or target is from Primordial loader
    * @return Stream of call graph edges (lazy evaluation)
    */
   public static Stream<CallGraphEdge> extractEdgesAsStream(CallGraph cg, boolean includeRt) {
     return StreamSupport.stream(
-        Spliterators.spliteratorUnknownSize(cg.iterator(), Spliterator.ORDERED),
-        false
-      )
-      .flatMap(sourceNode -> {
-        IMethod sourceMethod = sourceNode.getMethod();
-        TypeName sourceType = sourceMethod.getDeclaringClass().getName();
-        Selector sourceSelector = sourceMethod.getSelector();
-        String sourceUri = formatMethod(sourceType, sourceSelector);
-        
-        // Skip if source cannot be formatted
-        if (sourceUri == null) {
-          return Stream.empty();
-        }
-        
-        // Normalize source (convert fake root to <boot>)
-        String normalizedSourceUri = normalizeSourceUri(sourceUri);
-        
-        // Get successor nodes (targets) for this source
-        Iterator<CGNode> targets = cg.getSuccNodes(sourceNode);
-        
-        return StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(targets, Spliterator.ORDERED),
-            false
-          )
-          .map(targetNode -> {
-            IMethod targetMethod = targetNode.getMethod();
-            TypeName targetType = targetMethod.getDeclaringClass().getName();
-            Selector targetSelector = targetMethod.getSelector();
-            String targetUri = formatMethod(targetType, targetSelector);
-            
-            return new EdgeCandidate(normalizedSourceUri, targetUri, sourceMethod, targetMethod);
-          })
-          .filter(candidate -> !shouldSkipTarget(candidate.targetUri))
-          .filter(candidate -> !shouldFilterRtEdge(candidate.sourceMethod, candidate.targetMethod, includeRt))
-          .map(candidate -> new CallGraphEdge(candidate.sourceUri, candidate.targetUri));
-      });
+            Spliterators.spliteratorUnknownSize(cg.iterator(), Spliterator.ORDERED), false)
+        .flatMap(
+            sourceNode -> {
+              IMethod sourceMethod = sourceNode.getMethod();
+              TypeName sourceType = sourceMethod.getDeclaringClass().getName();
+              Selector sourceSelector = sourceMethod.getSelector();
+              String sourceUri = formatMethod(sourceType, sourceSelector);
+
+              // Skip if source cannot be formatted
+              if (sourceUri == null) {
+                return Stream.empty();
+              }
+
+              // Normalize source (convert fake root to <boot>)
+              String normalizedSourceUri = normalizeSourceUri(sourceUri);
+
+              // Get successor nodes (targets) for this source
+              Iterator<CGNode> targets = cg.getSuccNodes(sourceNode);
+
+              return StreamSupport.stream(
+                      Spliterators.spliteratorUnknownSize(targets, Spliterator.ORDERED), false)
+                  .map(
+                      targetNode -> {
+                        IMethod targetMethod = targetNode.getMethod();
+                        TypeName targetType = targetMethod.getDeclaringClass().getName();
+                        Selector targetSelector = targetMethod.getSelector();
+                        String targetUri = formatMethod(targetType, targetSelector);
+
+                        return new EdgeCandidate(
+                            normalizedSourceUri, targetUri, sourceMethod, targetMethod);
+                      })
+                  .filter(candidate -> !shouldSkipTarget(candidate.targetUri))
+                  .filter(
+                      candidate ->
+                          !shouldFilterRtEdge(
+                              candidate.sourceMethod, candidate.targetMethod, includeRt))
+                  .map(candidate -> new CallGraphEdge(candidate.sourceUri, candidate.targetUri));
+            });
   }
 
-  /**
-   * Temporary holder for edge candidate during stream processing.
-   */
+  /** Temporary holder for edge candidate during stream processing. */
   private static class EdgeCandidate {
     final String sourceUri;
     final String targetUri;
     final IMethod sourceMethod;
     final IMethod targetMethod;
-    
+
     EdgeCandidate(String sourceUri, String targetUri, IMethod sourceMethod, IMethod targetMethod) {
       this.sourceUri = sourceUri;
       this.targetUri = targetUri;
@@ -264,9 +241,7 @@ public class WalaCallGraphBuilder {
     }
   }
 
-  /**
-   * Represents a call graph edge.
-   */
+  /** Represents a call graph edge. */
   public static class CallGraphEdge {
     /** Source method URI. */
     public final String source;

--- a/src/main/java/net/cg4j/WalaCallGraphBuilder.java
+++ b/src/main/java/net/cg4j/WalaCallGraphBuilder.java
@@ -72,8 +72,13 @@ public class WalaCallGraphBuilder {
   /**
    * Constructs Class Hierarchy with exclusions.
    *
-   * <p>Scope organization: - Primordial: rt.jar (Java runtime) - always loaded for class hierarchy
-   * - Extension: dependency JARs - Application: target JAR being analyzed
+   * <p>Scope organization:
+   *
+   * <ul>
+   *   <li>Primordial: rt.jar (Java runtime) - always loaded for class hierarchy
+   *   <li>Extension: dependency JARs
+   *   <li>Application: target JAR being analyzed
+   * </ul>
    */
   private ClassHierarchy constructCHA(
       String programJarFile, List<File> dependenciesJarFiles, File exclusionFile) throws Exception {

--- a/src/main/java/net/cg4j/asm/AsmCallGraphBuilder.java
+++ b/src/main/java/net/cg4j/asm/AsmCallGraphBuilder.java
@@ -1,13 +1,5 @@
 package net.cg4j.asm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,10 +16,15 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
-/**
- * Builds call graphs using ASM with RTA-based virtual call resolution.
- */
+/** Builds call graphs using ASM with RTA-based virtual call resolution. */
 public final class AsmCallGraphBuilder {
 
   private static final Logger logger = LogManager.getLogger(AsmCallGraphBuilder.class);
@@ -37,28 +34,28 @@ public final class AsmCallGraphBuilder {
       new MethodSignature("<boot>", "fakeRoot", "()V");
   private static final MethodSignature FAKE_WORLD_CLINIT_METHOD =
       new MethodSignature("<boot>", "fakeWorldClinit", "()V");
-  private static final List<String> PRE_ALLOCATED_TYPES = List.of(
-      "java/lang/Object",
-      "java/lang/ArithmeticException",
-      "java/lang/ArrayStoreException",
-      "java/lang/Class",
-      "java/lang/ClassLoader",
-      "java/lang/ClassCastException",
-      "java/lang/ClassNotFoundException",
-      "java/lang/Number",
-      "java/lang/reflect/AccessibleObject",
-      "java/lang/reflect/Constructor",
-      "java/lang/reflect/Executable",
-      "java/lang/IndexOutOfBoundsException",
-      "java/lang/NegativeArraySizeException",
-      "java/lang/ExceptionInInitializerError",
-      "java/lang/NullPointerException",
-      "java/lang/SecurityManager",
-      "java/lang/String",
-      "java/lang/StringBuilder",
-      "java/lang/Thread",
-      "java/lang/ThreadGroup"
-  );
+  private static final List<String> PRE_ALLOCATED_TYPES =
+      List.of(
+          "java/lang/Object",
+          "java/lang/ArithmeticException",
+          "java/lang/ArrayStoreException",
+          "java/lang/Class",
+          "java/lang/ClassLoader",
+          "java/lang/ClassCastException",
+          "java/lang/ClassNotFoundException",
+          "java/lang/Number",
+          "java/lang/reflect/AccessibleObject",
+          "java/lang/reflect/Constructor",
+          "java/lang/reflect/Executable",
+          "java/lang/IndexOutOfBoundsException",
+          "java/lang/NegativeArraySizeException",
+          "java/lang/ExceptionInInitializerError",
+          "java/lang/NullPointerException",
+          "java/lang/SecurityManager",
+          "java/lang/String",
+          "java/lang/StringBuilder",
+          "java/lang/Thread",
+          "java/lang/ThreadGroup");
 
   private ClassHierarchy hierarchy;
   private Map<String, byte[]> classBytecode;
@@ -66,9 +63,7 @@ public final class AsmCallGraphBuilder {
   private final Map<String, Integer> lambdaCounters = new HashMap<>();
   private final Map<MethodSignature, LambdaImplementation> lambdaImplementations = new HashMap<>();
 
-  /**
-   * Creates an ASM-backed call graph builder.
-   */
+  /** Creates an ASM-backed call graph builder. */
   public AsmCallGraphBuilder() {}
 
   /**
@@ -81,8 +76,8 @@ public final class AsmCallGraphBuilder {
    * @return the call graph result
    * @throws IOException if class metadata or bytecode cannot be read
    */
-  public CallGraphResult buildCallGraph(String jarFile, List<File> dependencies,
-                                        boolean includeRt, ScopeExclusions exclusions)
+  public CallGraphResult buildCallGraph(
+      String jarFile, List<File> dependencies, boolean includeRt, ScopeExclusions exclusions)
       throws IOException {
     logger.info("Loading classes...");
     lambdaCounters.clear();
@@ -113,8 +108,11 @@ public final class AsmCallGraphBuilder {
     allClasses = exclusions.applyExclusions(allClasses);
     int excludedCount = beforeSize - allClasses.size();
     if (excludedCount > 0) {
-      logger.info("Scope reduced to {} classes ({} excluded, {} patterns)",
-          allClasses.size(), excludedCount, exclusions.patternCount());
+      logger.info(
+          "Scope reduced to {} classes ({} excluded, {} patterns)",
+          allClasses.size(),
+          excludedCount,
+          exclusions.patternCount());
     }
 
     logger.info("Building class hierarchy...");
@@ -147,8 +145,8 @@ public final class AsmCallGraphBuilder {
   }
 
   /**
-   * Finds all entry points from application classes.
-   * Entry points are public, non-abstract methods from public, non-interface classes.
+   * Finds all entry points from application classes. Entry points are public, non-abstract methods
+   * from public, non-interface classes.
    */
   private Set<MethodSignature> findEntryPoints(Map<String, ClassInfo> appClasses) {
     Set<MethodSignature> entryPoints = new HashSet<>();
@@ -168,9 +166,7 @@ public final class AsmCallGraphBuilder {
     return entryPoints;
   }
 
-  /**
-   * Runs the worklist algorithm to compute reachable methods and call edges.
-   */
+  /** Runs the worklist algorithm to compute reachable methods and call edges. */
   private WorklistResult runWorklist(Set<MethodSignature> entryPoints) {
     RtaState state = new RtaState();
 
@@ -186,8 +182,11 @@ public final class AsmCallGraphBuilder {
 
         processedCount++;
         if (processedCount % 1000 == 0) {
-          logger.debug("Processed {} methods, pending methods: {}, pending receiver events: {}",
-              processedCount, state.methodQueue.size(), state.receiverEvents.size());
+          logger.debug(
+              "Processed {} methods, pending methods: {}, pending receiver events: {}",
+              processedCount,
+              state.methodQueue.size(),
+              state.receiverEvents.size());
         }
 
         processReachableMethod(method, state);
@@ -202,14 +201,14 @@ public final class AsmCallGraphBuilder {
       }
     }
 
-    logger.info("Worklist complete: {} reachable methods, {} edges",
-        state.reachable.size(), state.edges.size());
+    logger.info(
+        "Worklist complete: {} reachable methods, {} edges",
+        state.reachable.size(),
+        state.edges.size());
     return new WorklistResult(state.reachable, state.edges);
   }
 
-  /**
-   * Seeds the worklist with WALA-style fake root calls and allocations.
-   */
+  /** Seeds the worklist with WALA-style fake root calls and allocations. */
   private void seedFakeRoot(Set<MethodSignature> entryPoints, RtaState state) {
     for (MethodSignature entryPoint : entryPoints) {
       processFakeRootEntrypoint(entryPoint, state);
@@ -220,9 +219,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Adds a WALA-style fake root call for an entry point if its arguments can be materialized.
-   */
+  /** Adds a WALA-style fake root call for an entry point if its arguments can be materialized. */
   private void processFakeRootEntrypoint(MethodSignature entryPoint, RtaState state) {
     if (!allocateFakeRootArguments(entryPoint, state)) {
       return;
@@ -235,8 +232,7 @@ public final class AsmCallGraphBuilder {
    * Materializes fake root arguments for an entry point, including {@code this} for instance calls.
    */
   private boolean allocateFakeRootArguments(MethodSignature entryPoint, RtaState state) {
-    if (!entryPoint.isStatic()
-        && !allocateFakeRootObject(entryPoint.getOwner(), true, state)) {
+    if (!entryPoint.isStatic() && !allocateFakeRootObject(entryPoint.getOwner(), true, state)) {
       return false;
     }
 
@@ -249,9 +245,7 @@ public final class AsmCallGraphBuilder {
     return true;
   }
 
-  /**
-   * Creates the synthetic fake root call site for an entry point using JVM dispatch semantics.
-   */
+  /** Creates the synthetic fake root call site for an entry point using JVM dispatch semantics. */
   private CallSite createFakeRootCallSite(MethodSignature entryPoint) {
     ClassInfo ownerClass = hierarchy.getClass(entryPoint.getOwner());
     boolean isInterface = ownerClass != null && ownerClass.isInterface();
@@ -275,9 +269,7 @@ public final class AsmCallGraphBuilder {
         isInterface);
   }
 
-  /**
-   * Allocates a fake root argument following WALA's declared-parameter strategy.
-   */
+  /** Allocates a fake root argument following WALA's declared-parameter strategy. */
   private boolean allocateFakeRootType(Type type, RtaState state) {
     switch (type.getSort()) {
       case Type.OBJECT:
@@ -289,9 +281,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Allocates an array argument by materializing one representative reference element, if any.
-   */
+  /** Allocates an array argument by materializing one representative reference element, if any. */
   private boolean allocateFakeRootArray(Type arrayType, RtaState state) {
     Type elementType = arrayType;
     while (elementType.getSort() == Type.ARRAY) {
@@ -305,11 +295,9 @@ public final class AsmCallGraphBuilder {
     return true;
   }
 
-  /**
-   * Allocates a fake root object when the class is available in the hierarchy.
-   */
-  private boolean allocateFakeRootObject(String className, boolean invokeDefaultConstructor,
-                                         RtaState state) {
+  /** Allocates a fake root object when the class is available in the hierarchy. */
+  private boolean allocateFakeRootObject(
+      String className, boolean invokeDefaultConstructor, RtaState state) {
     ClassInfo klass = hierarchy.getClass(className);
     if (klass == null) {
       return false;
@@ -330,9 +318,7 @@ public final class AsmCallGraphBuilder {
     return true;
   }
 
-  /**
-   * Adds the default constructor call emitted by WALA's fake root allocation logic.
-   */
+  /** Adds the default constructor call emitted by WALA's fake root allocation logic. */
   private void addFakeRootDefaultConstructor(String className, RtaState state) {
     MethodSignature constructor = hierarchy.getClass(className).getMethod("<init>", "()V");
     if (constructor != null) {
@@ -340,9 +326,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Processes the bytecode summary for a newly reachable method.
-   */
+  /** Processes the bytecode summary for a newly reachable method. */
   private void processReachableMethod(MethodSignature method, RtaState state) {
     MethodAnalysisResult analysisResult = analyzeMethod(method);
 
@@ -363,13 +347,12 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Processes a single call site according to its JVM dispatch semantics.
-   */
+  /** Processes a single call site according to its JVM dispatch semantics. */
   private void processCallSite(MethodSignature caller, CallSite callSite, RtaState state) {
     if (callSite.isStatic()) {
-      for (MethodSignature target : hierarchy.resolveStaticOrSpecialCall(
-          callSite.getOwner(), callSite.getName(), callSite.getDescriptor())) {
+      for (MethodSignature target :
+          hierarchy.resolveStaticOrSpecialCall(
+              callSite.getOwner(), callSite.getName(), callSite.getDescriptor())) {
         addResolvedTarget(caller, target, state);
       }
       processClassInitializer(callSite.getOwner(), state);
@@ -377,8 +360,9 @@ public final class AsmCallGraphBuilder {
     }
 
     if (callSite.isSpecial()) {
-      for (MethodSignature target : hierarchy.resolveStaticOrSpecialCall(
-          callSite.getOwner(), callSite.getName(), callSite.getDescriptor())) {
+      for (MethodSignature target :
+          hierarchy.resolveStaticOrSpecialCall(
+              callSite.getOwner(), callSite.getName(), callSite.getDescriptor())) {
         addResolvedTarget(caller, target, state);
       }
       return;
@@ -398,9 +382,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Processes a newly allocated concrete type and registers it against selector buckets.
-   */
+  /** Processes a newly allocated concrete type and registers it against selector buckets. */
   private void handleNewAllocation(String allocatedType, RtaState state) {
     ClassInfo klass = hierarchy.getClass(allocatedType);
     if (klass == null || klass.isInterface() || klass.isAbstract()) {
@@ -444,10 +426,9 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Registers selector-to-concrete-type membership for all methods declared on a type.
-   */
-  private void registerImplementedMethods(String declarerType, String concreteType, RtaState state) {
+  /** Registers selector-to-concrete-type membership for all methods declared on a type. */
+  private void registerImplementedMethods(
+      String declarerType, String concreteType, RtaState state) {
     ClassInfo declarer = hierarchy.getClass(declarerType);
     if (declarer == null) {
       return;
@@ -455,17 +436,15 @@ public final class AsmCallGraphBuilder {
 
     for (MethodSignature method : declarer.getMethods()) {
       SelectorKey selector = SelectorKey.from(method);
-      Set<String> bucket = state.selectorToReceiverTypes.computeIfAbsent(
-          selector, key -> new HashSet<>());
+      Set<String> bucket =
+          state.selectorToReceiverTypes.computeIfAbsent(selector, key -> new HashSet<>());
       if (bucket.add(concreteType)) {
         state.receiverEvents.addLast(new ReceiverEvent(selector, concreteType));
       }
     }
   }
 
-  /**
-   * Resolves a virtual call site for a newly discovered receiver type.
-   */
+  /** Resolves a virtual call site for a newly discovered receiver type. */
   private void tryDispatch(VirtualCallUse use, String concreteType, RtaState state) {
     if (!use.processedTypes.add(concreteType)) {
       return;
@@ -475,8 +454,9 @@ public final class AsmCallGraphBuilder {
       return;
     }
 
-    MethodSignature target = hierarchy.resolveVirtualTarget(
-        concreteType, use.callSite.getName(), use.callSite.getDescriptor());
+    MethodSignature target =
+        hierarchy.resolveVirtualTarget(
+            concreteType, use.callSite.getName(), use.callSite.getDescriptor());
     if (target == null || target.isAbstract()) {
       return;
     }
@@ -484,9 +464,7 @@ public final class AsmCallGraphBuilder {
     addResolvedTarget(use.caller, target, state);
   }
 
-  /**
-   * Adds a resolved call graph edge and enqueues the target if it becomes reachable.
-   */
+  /** Adds a resolved call graph edge and enqueues the target if it becomes reachable. */
   private void addResolvedTarget(MethodSignature caller, MethodSignature target, RtaState state) {
     if (state.edges.add(new CallGraphResult.Edge(caller, target))
         && !isCloneMethod(target)
@@ -495,9 +473,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Triggers a class initializer and its superclass initializers exactly once.
-   */
+  /** Triggers a class initializer and its superclass initializers exactly once. */
   private void processClassInitializer(String className, RtaState state) {
     ClassInfo klass = hierarchy.getClass(className);
     if (klass == null || !state.processedClinits.add(className)) {
@@ -517,18 +493,18 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Result of analyzing a method's bytecode.
-   */
+  /** Result of analyzing a method's bytecode. */
   private static class MethodAnalysisResult {
     final List<CallSite> callSites;
     final Set<String> instantiatedTypes;
     final Set<String> staticFieldOwners;
     final List<LambdaCallSite> lambdaCallSites;
 
-    MethodAnalysisResult(List<CallSite> callSites, Set<String> instantiatedTypes,
-                         Set<String> staticFieldOwners,
-                         List<LambdaCallSite> lambdaCallSites) {
+    MethodAnalysisResult(
+        List<CallSite> callSites,
+        Set<String> instantiatedTypes,
+        Set<String> staticFieldOwners,
+        List<LambdaCallSite> lambdaCallSites) {
       this.callSites = callSites;
       this.instantiatedTypes = instantiatedTypes;
       this.staticFieldOwners = staticFieldOwners;
@@ -565,29 +541,36 @@ public final class AsmCallGraphBuilder {
   }
 
   /**
-   * Processes a single lambda INVOKEDYNAMIC call site by creating a synthetic lambda class
-   * and edges matching WALA's two-hop pattern: caller -> SAM, SAM -> impl.
+   * Processes a single lambda INVOKEDYNAMIC call site by creating a synthetic lambda class and
+   * edges matching WALA's two-hop pattern: caller -> SAM, SAM -> impl.
    */
-  private void processLambdaCallSite(MethodSignature caller, LambdaCallSite lambda, RtaState state) {
+  private void processLambdaCallSite(
+      MethodSignature caller, LambdaCallSite lambda, RtaState state) {
     String syntheticName = generateLambdaClassName(caller.getOwner());
     ClassLoaderType syntheticLoaderType = getSyntheticLambdaLoaderType(caller);
 
-    MethodSignature samMethod = new MethodSignature(
-        syntheticName, lambda.getSamMethodName(), lambda.getSamDescriptor(),
-        Opcodes.ACC_PUBLIC);
+    MethodSignature samMethod =
+        new MethodSignature(
+            syntheticName,
+            lambda.getSamMethodName(),
+            lambda.getSamDescriptor(),
+            Opcodes.ACC_PUBLIC);
 
     String functionalInterface = extractFunctionalInterface(lambda);
-    Set<String> interfaces = functionalInterface != null
-        ? Collections.singleton(functionalInterface) : Collections.emptySet();
+    Set<String> interfaces =
+        functionalInterface != null
+            ? Collections.singleton(functionalInterface)
+            : Collections.emptySet();
 
-    ClassInfo syntheticClass = new ClassInfo(
-        syntheticName,
-        "java/lang/Object",
-        interfaces,
-        Collections.singleton(samMethod),
-        Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC,
-        syntheticLoaderType,
-        false);
+    ClassInfo syntheticClass =
+        new ClassInfo(
+            syntheticName,
+            "java/lang/Object",
+            interfaces,
+            Collections.singleton(samMethod),
+            Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC,
+            syntheticLoaderType,
+            false);
 
     hierarchy.registerSyntheticClass(syntheticClass);
     lambdaImplementations.put(samMethod, LambdaImplementation.from(lambda, hierarchy));
@@ -598,15 +581,16 @@ public final class AsmCallGraphBuilder {
    * Reuses the caller's loader type so synthetic lambdas are filtered like their originating code.
    */
   private ClassLoaderType getSyntheticLambdaLoaderType(MethodSignature caller) {
-    ClassInfo callerClass = Objects.requireNonNull(
-        hierarchy.getClass(caller.getOwner()),
-        "Expected caller class in hierarchy: " + caller.getOwner());
+    ClassInfo callerClass =
+        Objects.requireNonNull(
+            hierarchy.getClass(caller.getOwner()),
+            "Expected caller class in hierarchy: " + caller.getOwner());
     return callerClass.getLoaderType();
   }
 
   /**
-   * Generates a WALA-compatible synthetic lambda class name.
-   * Format: wala/lambda$owner_with_slashes_as_dollars$index
+   * Generates a WALA-compatible synthetic lambda class name. Format:
+   * wala/lambda$owner_with_slashes_as_dollars$index
    */
   private String generateLambdaClassName(String ownerClass) {
     int index = lambdaCounters.merge(ownerClass, 0, (old, value) -> old + 1);
@@ -636,18 +620,14 @@ public final class AsmCallGraphBuilder {
     return null;
   }
 
-  /**
-   * Returns true for the special clone() dispatch that WALA keeps only as an edge.
-   */
+  /** Returns true for the special clone() dispatch that WALA keeps only as an edge. */
   private boolean isCloneMethod(MethodSignature method) {
     return method.getOwner().equals("java/lang/Object")
         && method.getName().equals("clone")
         && method.getDescriptor().equals("()Ljava/lang/Object;");
   }
 
-  /**
-   * Loads bytecode for classes from JAR files.
-   */
+  /** Loads bytecode for classes from JAR files. */
   private void loadBytecode(List<File> jarFiles, Map<String, byte[]> bytecodeMap)
       throws IOException {
     for (File jarFile : jarFiles) {
@@ -671,9 +651,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Filters out edges involving Primordial (JDK) classes.
-   */
+  /** Filters out edges involving Primordial (JDK) classes. */
   private Set<CallGraphResult.Edge> filterRtEdges(Set<CallGraphResult.Edge> edges) {
     Set<CallGraphResult.Edge> filtered = new HashSet<>();
 
@@ -682,10 +660,11 @@ public final class AsmCallGraphBuilder {
       ClassInfo targetClass = hierarchy.getClass(edge.getTarget().getOwner());
 
       boolean sourceIsBoot = edge.getSource().getOwner().equals("<boot>");
-      boolean sourceIsPrimordial = sourceIsBoot || sourceClass != null
-          && sourceClass.getLoaderType() == ClassLoaderType.PRIMORDIAL;
-      boolean targetIsPrimordial = targetClass != null
-          && targetClass.getLoaderType() == ClassLoaderType.PRIMORDIAL;
+      boolean sourceIsPrimordial =
+          sourceIsBoot
+              || sourceClass != null && sourceClass.getLoaderType() == ClassLoaderType.PRIMORDIAL;
+      boolean targetIsPrimordial =
+          targetClass != null && targetClass.getLoaderType() == ClassLoaderType.PRIMORDIAL;
 
       if (!sourceIsPrimordial && !targetIsPrimordial) {
         filtered.add(edge);
@@ -695,9 +674,7 @@ public final class AsmCallGraphBuilder {
     return filtered;
   }
 
-  /**
-   * Temporary holder for worklist algorithm results.
-   */
+  /** Temporary holder for worklist algorithm results. */
   private static class WorklistResult {
     final Set<MethodSignature> reachable;
     final Set<CallGraphResult.Edge> edges;
@@ -708,9 +685,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Mutable state for the RTA worklist.
-   */
+  /** Mutable state for the RTA worklist. */
   private static final class RtaState {
     private final Set<MethodSignature> reachable = new HashSet<>();
     private final Set<CallGraphResult.Edge> edges = new HashSet<>();
@@ -723,9 +698,7 @@ public final class AsmCallGraphBuilder {
     private final Deque<ReceiverEvent> receiverEvents = new ArrayDeque<>();
   }
 
-  /**
-   * Records that a selector bucket gained a new concrete receiver type.
-   */
+  /** Records that a selector bucket gained a new concrete receiver type. */
   private static final class ReceiverEvent {
     private final SelectorKey selector;
     private final String concreteType;
@@ -736,9 +709,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Tracks which receiver types have already been processed for a virtual call site.
-   */
+  /** Tracks which receiver types have already been processed for a virtual call site. */
   private static final class VirtualCallUse {
     private final MethodSignature caller;
     private final CallSite callSite;
@@ -750,9 +721,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Synthetic lambda trampoline body that mirrors WALA's summary-method dispatch.
-   */
+  /** Synthetic lambda trampoline body that mirrors WALA's summary-method dispatch. */
   private static final class LambdaImplementation {
     private final CallSite callSite;
     private final Set<String> instantiatedTypes;
@@ -786,7 +755,8 @@ public final class AsmCallGraphBuilder {
           isInterface = true;
           break;
         default:
-          throw new IllegalArgumentException("Unsupported lambda handle tag: " + lambda.getImplTag());
+          throw new IllegalArgumentException(
+              "Unsupported lambda handle tag: " + lambda.getImplTag());
       }
 
       ClassInfo implOwner = hierarchy.getClass(lambda.getImplOwner());
@@ -794,12 +764,13 @@ public final class AsmCallGraphBuilder {
         isInterface = true;
       }
 
-      CallSite callSite = new CallSite(
-          opcode,
-          lambda.getImplOwner(),
-          lambda.getImplName(),
-          lambda.getImplDescriptor(),
-          isInterface);
+      CallSite callSite =
+          new CallSite(
+              opcode,
+              lambda.getImplOwner(),
+              lambda.getImplName(),
+              lambda.getImplDescriptor(),
+              isInterface);
       return new LambdaImplementation(callSite, instantiatedTypes);
     }
 
@@ -812,9 +783,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * Selector identity used by the WALA-style receiver buckets.
-   */
+  /** Selector identity used by the WALA-style receiver buckets. */
   private static final class SelectorKey {
     private final String name;
     private final String descriptor;
@@ -841,8 +810,7 @@ public final class AsmCallGraphBuilder {
         return false;
       }
       SelectorKey that = (SelectorKey) other;
-      return Objects.equals(name, that.name)
-          && Objects.equals(descriptor, that.descriptor);
+      return Objects.equals(name, that.name) && Objects.equals(descriptor, that.descriptor);
     }
 
     @Override
@@ -851,9 +819,7 @@ public final class AsmCallGraphBuilder {
     }
   }
 
-  /**
-   * ClassVisitor that extracts call sites and allocations from a specific method.
-   */
+  /** ClassVisitor that extracts call sites and allocations from a specific method. */
   private static class MethodAnalysisVisitor extends ClassVisitor {
     private final String targetMethodName;
     private final String targetDescriptor;
@@ -869,8 +835,8 @@ public final class AsmCallGraphBuilder {
     }
 
     @Override
-    public MethodVisitor visitMethod(int access, String name, String descriptor,
-                                     String signature, String[] exceptions) {
+    public MethodVisitor visitMethod(
+        int access, String name, String descriptor, String signature, String[] exceptions) {
       if (name.equals(targetMethodName) && descriptor.equals(targetDescriptor)) {
         CallSiteExtractor extractor = new CallSiteExtractor();
         callSites = extractor.getCallSites();

--- a/src/main/java/net/cg4j/asm/CallGraphResult.java
+++ b/src/main/java/net/cg4j/asm/CallGraphResult.java
@@ -3,9 +3,7 @@ package net.cg4j.asm;
 import java.util.Collections;
 import java.util.Set;
 
-/**
- * Contains the result of call graph construction.
- */
+/** Contains the result of call graph construction. */
 public final class CallGraphResult {
 
   private final Set<Edge> edges;
@@ -49,9 +47,7 @@ public final class CallGraphResult {
     return edges.size();
   }
 
-  /**
-   * Represents a directed edge in the call graph.
-   */
+  /** Represents a directed edge in the call graph. */
   public static final class Edge {
     private final MethodSignature source;
     private final MethodSignature target;

--- a/src/main/java/net/cg4j/asm/CallSite.java
+++ b/src/main/java/net/cg4j/asm/CallSite.java
@@ -2,9 +2,7 @@ package net.cg4j.asm;
 
 import org.objectweb.asm.Opcodes;
 
-/**
- * Represents a method invocation instruction found in bytecode.
- */
+/** Represents a method invocation instruction found in bytecode. */
 public final class CallSite {
 
   private final int opcode;
@@ -115,11 +113,21 @@ public final class CallSite {
   public String toString() {
     String opcodeStr;
     switch (opcode) {
-      case Opcodes.INVOKEVIRTUAL: opcodeStr = "INVOKEVIRTUAL"; break;
-      case Opcodes.INVOKEINTERFACE: opcodeStr = "INVOKEINTERFACE"; break;
-      case Opcodes.INVOKESPECIAL: opcodeStr = "INVOKESPECIAL"; break;
-      case Opcodes.INVOKESTATIC: opcodeStr = "INVOKESTATIC"; break;
-      default: opcodeStr = "INVOKE_" + opcode; break;
+      case Opcodes.INVOKEVIRTUAL:
+        opcodeStr = "INVOKEVIRTUAL";
+        break;
+      case Opcodes.INVOKEINTERFACE:
+        opcodeStr = "INVOKEINTERFACE";
+        break;
+      case Opcodes.INVOKESPECIAL:
+        opcodeStr = "INVOKESPECIAL";
+        break;
+      case Opcodes.INVOKESTATIC:
+        opcodeStr = "INVOKESTATIC";
+        break;
+      default:
+        opcodeStr = "INVOKE_" + opcode;
+        break;
     }
     return opcodeStr + " " + owner + "." + name + descriptor;
   }

--- a/src/main/java/net/cg4j/asm/CallSiteExtractor.java
+++ b/src/main/java/net/cg4j/asm/CallSiteExtractor.java
@@ -1,18 +1,15 @@
 package net.cg4j.asm;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-/**
- * ASM MethodVisitor that extracts call sites and instantiated types from method bytecode.
- */
+/** ASM MethodVisitor that extracts call sites and instantiated types from method bytecode. */
 public final class CallSiteExtractor extends MethodVisitor {
 
   private static final String LAMBDA_METAFACTORY = "java/lang/invoke/LambdaMetafactory";
@@ -22,16 +19,14 @@ public final class CallSiteExtractor extends MethodVisitor {
   private final Set<String> instantiatedTypes = new HashSet<>();
   private final Set<String> staticFieldOwners = new HashSet<>();
 
-  /**
-   * Creates a call site extractor.
-   */
+  /** Creates a call site extractor. */
   public CallSiteExtractor() {
     super(Opcodes.ASM9);
   }
 
   @Override
-  public void visitMethodInsn(int opcode, String owner, String name, String descriptor,
-                              boolean isInterface) {
+  public void visitMethodInsn(
+      int opcode, String owner, String name, String descriptor, boolean isInterface) {
     // Skip lambda metafactory calls (INVOKEDYNAMIC bootstrap target)
     if (owner.equals(LAMBDA_METAFACTORY)) {
       return;
@@ -41,9 +36,11 @@ public final class CallSiteExtractor extends MethodVisitor {
   }
 
   @Override
-  public void visitInvokeDynamicInsn(String name, String descriptor,
-                                     Handle bootstrapMethodHandle,
-                                     Object... bootstrapMethodArguments) {
+  public void visitInvokeDynamicInsn(
+      String name,
+      String descriptor,
+      Handle bootstrapMethodHandle,
+      Object... bootstrapMethodArguments) {
     if (!isLambdaMetafactory(bootstrapMethodHandle)) {
       return;
     }
@@ -57,15 +54,15 @@ public final class CallSiteExtractor extends MethodVisitor {
         && bootstrapMethodArguments[1] instanceof Handle) {
       Type samType = (Type) bootstrapMethodArguments[0];
       Handle implHandle = (Handle) bootstrapMethodArguments[1];
-      lambdaCallSites.add(new LambdaCallSite(
-          name,
-          samType.getDescriptor(),
-          descriptor,
-          implHandle.getOwner(),
-          implHandle.getName(),
-          implHandle.getDesc(),
-          implHandle.getTag()
-      ));
+      lambdaCallSites.add(
+          new LambdaCallSite(
+              name,
+              samType.getDescriptor(),
+              descriptor,
+              implHandle.getOwner(),
+              implHandle.getName(),
+              implHandle.getDesc(),
+              implHandle.getTag()));
     }
   }
 
@@ -119,12 +116,9 @@ public final class CallSiteExtractor extends MethodVisitor {
     return staticFieldOwners;
   }
 
-  /**
-   * Checks if a bootstrap method handle is LambdaMetafactory.metafactory or altMetafactory.
-   */
+  /** Checks if a bootstrap method handle is LambdaMetafactory.metafactory or altMetafactory. */
   private static boolean isLambdaMetafactory(Handle handle) {
     return handle.getOwner().equals(LAMBDA_METAFACTORY)
-        && (handle.getName().equals("metafactory")
-            || handle.getName().equals("altMetafactory"));
+        && (handle.getName().equals("metafactory") || handle.getName().equals("altMetafactory"));
   }
 }

--- a/src/main/java/net/cg4j/asm/ClassHierarchy.java
+++ b/src/main/java/net/cg4j/asm/ClassHierarchy.java
@@ -1,18 +1,15 @@
 package net.cg4j.asm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-/**
- * Maintains class hierarchy information and resolves virtual calls using RTA.
- */
+/** Maintains class hierarchy information and resolves virtual calls using RTA. */
 public final class ClassHierarchy {
 
   private static final Logger logger = LogManager.getLogger(ClassHierarchy.class);
@@ -37,9 +34,7 @@ public final class ClassHierarchy {
     buildReverseRelations();
   }
 
-  /**
-   * Builds reverse relations (subclass and implementor maps).
-   */
+  /** Builds reverse relations (subclass and implementor maps). */
   private void buildReverseRelations() {
     for (ClassInfo info : classes.values()) {
       // Track subclass relation
@@ -105,8 +100,8 @@ public final class ClassHierarchy {
   }
 
   /**
-   * Returns all subtypes (transitive) of a type, including itself.
-   * Results are cached for performance.
+   * Returns all subtypes (transitive) of a type, including itself. Results are cached for
+   * performance.
    *
    * @param typeName the internal type name
    * @return the transitive subtype closure including {@code typeName}
@@ -115,9 +110,7 @@ public final class ClassHierarchy {
     return subtypesCache.computeIfAbsent(typeName, this::computeAllSubtypes);
   }
 
-  /**
-   * Computes all subtypes transitively.
-   */
+  /** Computes all subtypes transitively. */
   private Set<String> computeAllSubtypes(String typeName) {
     Set<String> result = new HashSet<>();
     result.add(typeName);
@@ -125,9 +118,7 @@ public final class ClassHierarchy {
     return result;
   }
 
-  /**
-   * Recursively collects all subtypes.
-   */
+  /** Recursively collects all subtypes. */
   private void collectSubtypes(String typeName, Set<String> result) {
     // Collect subclasses
     for (String subclass : getDirectSubclasses(typeName)) {
@@ -179,12 +170,11 @@ public final class ClassHierarchy {
    * @return the transitive set of implemented interfaces
    */
   public Set<String> getAllImplementedInterfaces(String className) {
-    return implementedInterfacesCache.computeIfAbsent(className, this::computeAllImplementedInterfaces);
+    return implementedInterfacesCache.computeIfAbsent(
+        className, this::computeAllImplementedInterfaces);
   }
 
-  /**
-   * Computes all interfaces implemented by a class or interface, transitively.
-   */
+  /** Computes all interfaces implemented by a class or interface, transitively. */
   private Set<String> computeAllImplementedInterfaces(String className) {
     ClassInfo info = classes.get(className);
     if (info == null) {
@@ -236,8 +226,8 @@ public final class ClassHierarchy {
    * @param descriptor the target method descriptor
    * @return the resolved concrete target, or {@code null} if resolution fails
    */
-  public MethodSignature resolveVirtualTarget(String concreteType, String methodName,
-                                              String descriptor) {
+  public MethodSignature resolveVirtualTarget(
+      String concreteType, String methodName, String descriptor) {
     String current = concreteType;
 
     while (current != null) {
@@ -258,8 +248,8 @@ public final class ClassHierarchy {
   }
 
   /**
-   * Resolves a virtual call using RTA (Rapid Type Analysis).
-   * Only considers types that have been instantiated.
+   * Resolves a virtual call using RTA (Rapid Type Analysis). Only considers types that have been
+   * instantiated.
    *
    * @param receiverType the declared receiver type
    * @param methodName the method name
@@ -267,9 +257,8 @@ public final class ClassHierarchy {
    * @param instantiatedTypes set of types that have been instantiated via NEW
    * @return set of possible target methods
    */
-  public Set<MethodSignature> resolveVirtualCallRTA(String receiverType, String methodName,
-                                                     String descriptor,
-                                                     Set<String> instantiatedTypes) {
+  public Set<MethodSignature> resolveVirtualCallRTA(
+      String receiverType, String methodName, String descriptor, Set<String> instantiatedTypes) {
     Set<MethodSignature> targets = new HashSet<>();
 
     Set<String> subtypes = getAllSubtypes(receiverType);
@@ -307,27 +296,27 @@ public final class ClassHierarchy {
    */
   public Set<MethodSignature> resolveCallSiteRTA(CallSite callSite, Set<String> instantiatedTypes) {
     if (callSite.isStatic() || callSite.isSpecial()) {
-      return resolveStaticOrSpecialCall(callSite.getOwner(), callSite.getName(),
-          callSite.getDescriptor());
+      return resolveStaticOrSpecialCall(
+          callSite.getOwner(), callSite.getName(), callSite.getDescriptor());
     } else if (callSite.isVirtual()) {
-      return resolveVirtualCallRTA(callSite.getOwner(), callSite.getName(),
-          callSite.getDescriptor(), instantiatedTypes);
+      return resolveVirtualCallRTA(
+          callSite.getOwner(), callSite.getName(), callSite.getDescriptor(), instantiatedTypes);
     }
     // Unknown opcode
     return Collections.emptySet();
   }
 
   /**
-   * Resolves a static or special (constructor/private/super) call.
-   * Returns exactly one target method or empty set if not found.
+   * Resolves a static or special (constructor/private/super) call. Returns exactly one target
+   * method or empty set if not found.
    *
    * @param ownerType the owner class
    * @param methodName the method name
    * @param descriptor the method descriptor
    * @return set containing the target method, or empty set
    */
-  public Set<MethodSignature> resolveStaticOrSpecialCall(String ownerType, String methodName,
-                                                          String descriptor) {
+  public Set<MethodSignature> resolveStaticOrSpecialCall(
+      String ownerType, String methodName, String descriptor) {
     MethodSignature method = lookupMethod(ownerType, methodName, descriptor);
     if (method != null) {
       return Collections.singleton(method);
@@ -336,8 +325,8 @@ public final class ClassHierarchy {
   }
 
   /**
-   * Registers a synthetic class (e.g., lambda) into the hierarchy.
-   * Updates reverse relations and invalidates hierarchy caches.
+   * Registers a synthetic class (e.g., lambda) into the hierarchy. Updates reverse relations and
+   * invalidates hierarchy caches.
    *
    * @param syntheticClass the synthetic class to register
    */
@@ -346,12 +335,12 @@ public final class ClassHierarchy {
 
     // Update reverse relations
     if (syntheticClass.getSuperName() != null) {
-      subclasses.computeIfAbsent(syntheticClass.getSuperName(), k -> new HashSet<>())
+      subclasses
+          .computeIfAbsent(syntheticClass.getSuperName(), k -> new HashSet<>())
           .add(syntheticClass.getName());
     }
     for (String iface : syntheticClass.getInterfaces()) {
-      implementors.computeIfAbsent(iface, k -> new HashSet<>())
-          .add(syntheticClass.getName());
+      implementors.computeIfAbsent(iface, k -> new HashSet<>()).add(syntheticClass.getName());
     }
 
     // Invalidate caches — synthetic classes are leaf nodes but affect parent lookups
@@ -368,9 +357,7 @@ public final class ClassHierarchy {
     return classes.size();
   }
 
-  /**
-   * Collects transitive interfaces for a class.
-   */
+  /** Collects transitive interfaces for a class. */
   private void collectInterfaces(ClassInfo info, Set<String> result) {
     for (String iface : info.getInterfaces()) {
       if (result.add(iface)) {
@@ -390,12 +377,9 @@ public final class ClassHierarchy {
     }
   }
 
-  /**
-   * Looks for a non-abstract default method on implemented interfaces.
-   */
-  private MethodSignature lookupDefaultInterfaceMethod(String className, String methodName,
-                                                       String descriptor,
-                                                       Set<String> visitedInterfaces) {
+  /** Looks for a non-abstract default method on implemented interfaces. */
+  private MethodSignature lookupDefaultInterfaceMethod(
+      String className, String methodName, String descriptor, Set<String> visitedInterfaces) {
     ClassInfo info = classes.get(className);
     if (info == null) {
       return null;
@@ -417,12 +401,9 @@ public final class ClassHierarchy {
     return null;
   }
 
-  /**
-   * Looks for a concrete method declaration on an interface hierarchy.
-   */
-  private MethodSignature lookupInterfaceMethod(String interfaceName, String methodName,
-                                                String descriptor,
-                                                Set<String> visitedInterfaces) {
+  /** Looks for a concrete method declaration on an interface hierarchy. */
+  private MethodSignature lookupInterfaceMethod(
+      String interfaceName, String methodName, String descriptor, Set<String> visitedInterfaces) {
     if (!visitedInterfaces.add(interfaceName)) {
       return null;
     }

--- a/src/main/java/net/cg4j/asm/ClassInfo.java
+++ b/src/main/java/net/cg4j/asm/ClassInfo.java
@@ -4,9 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * Stores metadata about a class extracted from bytecode.
- */
+/** Stores metadata about a class extracted from bytecode. */
 public final class ClassInfo {
 
   private final String name;
@@ -28,9 +26,14 @@ public final class ClassInfo {
    * @param loaderType the class loader this class belongs to
    * @param hasClinit true if the class has a static initializer
    */
-  public ClassInfo(String name, String superName, Set<String> interfaces,
-                   Set<MethodSignature> methods, int access, ClassLoaderType loaderType,
-                   boolean hasClinit) {
+  public ClassInfo(
+      String name,
+      String superName,
+      Set<String> interfaces,
+      Set<MethodSignature> methods,
+      int access,
+      ClassLoaderType loaderType,
+      boolean hasClinit) {
     this.name = name;
     this.superName = superName;
     this.interfaces = Collections.unmodifiableSet(new HashSet<>(interfaces));

--- a/src/main/java/net/cg4j/asm/ClassInfoVisitor.java
+++ b/src/main/java/net/cg4j/asm/ClassInfoVisitor.java
@@ -1,16 +1,13 @@
 package net.cg4j.asm;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-/**
- * ASM ClassVisitor that extracts class metadata.
- */
+/** ASM ClassVisitor that extracts class metadata. */
 public final class ClassInfoVisitor extends ClassVisitor {
 
   private static final String CLINIT_NAME = "<clinit>";
@@ -35,8 +32,13 @@ public final class ClassInfoVisitor extends ClassVisitor {
   }
 
   @Override
-  public void visit(int version, int access, String name, String signature,
-                    String superName, String[] interfaces) {
+  public void visit(
+      int version,
+      int access,
+      String name,
+      String signature,
+      String superName,
+      String[] interfaces) {
     this.name = name;
     this.superName = superName;
     this.access = access;
@@ -46,8 +48,8 @@ public final class ClassInfoVisitor extends ClassVisitor {
   }
 
   @Override
-  public MethodVisitor visitMethod(int access, String name, String descriptor,
-                                   String signature, String[] exceptions) {
+  public MethodVisitor visitMethod(
+      int access, String name, String descriptor, String signature, String[] exceptions) {
     methods.add(new MethodSignature(this.name, name, descriptor, access));
     // Detect static initializer
     if (CLINIT_NAME.equals(name) && CLINIT_DESCRIPTOR.equals(descriptor)) {
@@ -58,8 +60,7 @@ public final class ClassInfoVisitor extends ClassVisitor {
   }
 
   /**
-   * Returns the extracted class info.
-   * Must be called after the class has been visited.
+   * Returns the extracted class info. Must be called after the class has been visited.
    *
    * @return the extracted class metadata
    */

--- a/src/main/java/net/cg4j/asm/ClassLoaderType.java
+++ b/src/main/java/net/cg4j/asm/ClassLoaderType.java
@@ -1,22 +1,14 @@
 package net.cg4j.asm;
 
-/**
- * Represents the different class loader scopes in the analysis.
- */
+/** Represents the different class loader scopes in the analysis. */
 public enum ClassLoaderType {
 
-  /**
-   * Java runtime classes (JDK/rt.jar).
-   */
+  /** Java runtime classes (JDK/rt.jar). */
   PRIMORDIAL,
 
-  /**
-   * Dependency JARs provided via -d option.
-   */
+  /** Dependency JARs provided via -d option. */
   EXTENSION,
 
-  /**
-   * Target JAR being analyzed.
-   */
+  /** Target JAR being analyzed. */
   APPLICATION
 }

--- a/src/main/java/net/cg4j/asm/JarScanner.java
+++ b/src/main/java/net/cg4j/asm/JarScanner.java
@@ -1,9 +1,5 @@
 package net.cg4j.asm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.objectweb.asm.ClassReader;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,10 +15,11 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.ClassReader;
 
-/**
- * Scans JAR files and JRT filesystem to extract class information using ASM.
- */
+/** Scans JAR files and JRT filesystem to extract class information using ASM. */
 public final class JarScanner {
 
   private static final Logger logger = LogManager.getLogger(JarScanner.class);
@@ -100,9 +97,7 @@ public final class JarScanner {
     return scanJrtFileSystem();
   }
 
-  /**
-   * Scans the jrt:/ filesystem for Java 9+ JDK classes.
-   */
+  /** Scans the jrt:/ filesystem for Java 9+ JDK classes. */
   private static Map<String, ClassInfo> scanJrtFileSystem() throws IOException {
     Map<String, ClassInfo> classes = new HashMap<>();
 
@@ -114,13 +109,14 @@ public final class JarScanner {
 
       Path modulesPath = JdkLocator.getJrtModulesPath(jrtFs);
       try (Stream<Path> modules = Files.list(modulesPath)) {
-        modules.forEach(modulePath -> {
-          try {
-            scanJrtModule(modulePath, classes);
-          } catch (IOException e) {
-            logger.warn("Failed to scan module {}: {}", modulePath, e.getMessage());
-          }
-        });
+        modules.forEach(
+            modulePath -> {
+              try {
+                scanJrtModule(modulePath, classes);
+              } catch (IOException e) {
+                logger.warn("Failed to scan module {}: {}", modulePath, e.getMessage());
+              }
+            });
       }
     }
 
@@ -128,29 +124,26 @@ public final class JarScanner {
     return classes;
   }
 
-  /**
-   * Scans a single module in the jrt:/ filesystem.
-   */
+  /** Scans a single module in the jrt:/ filesystem. */
   private static void scanJrtModule(Path modulePath, Map<String, ClassInfo> classes)
       throws IOException {
     try (Stream<Path> walk = Files.walk(modulePath)) {
       walk.filter(p -> p.toString().endsWith(".class"))
-          .forEach(classPath -> {
-            try (InputStream is = Files.newInputStream(classPath)) {
-              ClassInfo info = parseClass(is, ClassLoaderType.PRIMORDIAL);
-              if (info != null) {
-                classes.put(info.getName(), info);
-              }
-            } catch (Exception e) {
-              logger.trace("Failed to parse {}: {}", classPath, e.getMessage());
-            }
-          });
+          .forEach(
+              classPath -> {
+                try (InputStream is = Files.newInputStream(classPath)) {
+                  ClassInfo info = parseClass(is, ClassLoaderType.PRIMORDIAL);
+                  if (info != null) {
+                    classes.put(info.getName(), info);
+                  }
+                } catch (Exception e) {
+                  logger.trace("Failed to parse {}: {}", classPath, e.getMessage());
+                }
+              });
     }
   }
 
-  /**
-   * Parses a class file and returns ClassInfo.
-   */
+  /** Parses a class file and returns ClassInfo. */
   private static ClassInfo parseClass(InputStream is, ClassLoaderType loaderType)
       throws IOException {
     ClassReader reader = new ClassReader(is);
@@ -174,9 +167,9 @@ public final class JarScanner {
   }
 
   /**
-   * Creates a loader for lazily loading primordial (JDK) class bytecode.
-   * The returned loader caches the JDK file handle (jrt:/ filesystem or rt.jar)
-   * for efficient repeated lookups. Caller must close the loader when done.
+   * Creates a loader for lazily loading primordial (JDK) class bytecode. The returned loader caches
+   * the JDK file handle (jrt:/ filesystem or rt.jar) for efficient repeated lookups. Caller must
+   * close the loader when done.
    *
    * @return a new PrimordialBytecodeLoader
    * @throws IOException if the JDK runtime cannot be opened
@@ -190,8 +183,8 @@ public final class JarScanner {
   }
 
   /**
-   * Loads primordial class bytecode on demand. Implementations cache the underlying
-   * JDK file handle for efficient repeated lookups.
+   * Loads primordial class bytecode on demand. Implementations cache the underlying JDK file handle
+   * for efficient repeated lookups.
    */
   public interface PrimordialBytecodeLoader extends AutoCloseable {
 
@@ -207,9 +200,7 @@ public final class JarScanner {
     void close() throws IOException;
   }
 
-  /**
-   * Loads class bytecode from rt.jar (Java 8).
-   */
+  /** Loads class bytecode from rt.jar (Java 8). */
   private static class RtJarBytecodeLoader implements PrimordialBytecodeLoader {
     private final JarFile jar;
 
@@ -237,9 +228,7 @@ public final class JarScanner {
     }
   }
 
-  /**
-   * Loads class bytecode from the jrt:/ filesystem (Java 9+).
-   */
+  /** Loads class bytecode from the jrt:/ filesystem (Java 9+). */
   private static class JrtBytecodeLoader implements PrimordialBytecodeLoader {
     private final FileSystem jrtFs;
     private final List<Path> modulePaths;

--- a/src/main/java/net/cg4j/asm/JdkLocator.java
+++ b/src/main/java/net/cg4j/asm/JdkLocator.java
@@ -1,8 +1,5 @@
 package net.cg4j.asm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -12,10 +9,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-/**
- * Locates JDK runtime classes (rt.jar or jrt:/ for Java 9+).
- */
+/** Locates JDK runtime classes (rt.jar or jrt:/ for Java 9+). */
 public final class JdkLocator {
 
   private static final Logger logger = LogManager.getLogger(JdkLocator.class);
@@ -23,8 +20,8 @@ public final class JdkLocator {
   private JdkLocator() {}
 
   /**
-   * Returns the path to rt.jar for Java 8 or null for Java 9+.
-   * For Java 9+, use getJrtFileSystem() instead.
+   * Returns the path to rt.jar for Java 8 or null for Java 9+. For Java 9+, use getJrtFileSystem()
+   * instead.
    *
    * @return the {@code rt.jar} file, or {@code null} on Java 9+
    */
@@ -84,8 +81,8 @@ public final class JdkLocator {
   }
 
   /**
-   * Opens and returns the jrt:/ file system for Java 9+.
-   * Caller is responsible for closing the returned FileSystem.
+   * Opens and returns the jrt:/ file system for Java 9+. Caller is responsible for closing the
+   * returned FileSystem.
    *
    * @return FileSystem for jrt:/ or null if not available
    * @throws IOException if the JRT file system cannot be opened

--- a/src/main/java/net/cg4j/asm/LambdaCallSite.java
+++ b/src/main/java/net/cg4j/asm/LambdaCallSite.java
@@ -1,8 +1,8 @@
 package net.cg4j.asm;
 
 /**
- * Represents a lambda or method reference captured from an INVOKEDYNAMIC instruction
- * bootstrapped by {@code LambdaMetafactory.metafactory} or {@code altMetafactory}.
+ * Represents a lambda or method reference captured from an INVOKEDYNAMIC instruction bootstrapped
+ * by {@code LambdaMetafactory.metafactory} or {@code altMetafactory}.
  */
 public final class LambdaCallSite {
 
@@ -18,16 +18,23 @@ public final class LambdaCallSite {
    * Creates a lambda call site.
    *
    * @param samMethodName SAM method name (e.g., "invoke", "run", "apply")
-   * @param samDescriptor erased SAM method descriptor (e.g., "(Ljava/lang/Object;)Ljava/lang/Object;")
-   * @param indyDescriptor invokedynamic call-site descriptor (return type is the functional interface)
+   * @param samDescriptor erased SAM method descriptor (e.g.,
+   *     "(Ljava/lang/Object;)Ljava/lang/Object;")
+   * @param indyDescriptor invokedynamic call-site descriptor (return type is the functional
+   *     interface)
    * @param implOwner lambda body owner class in internal format
    * @param implName lambda body method name
    * @param implDescriptor lambda body method descriptor
    * @param implTag handle tag (e.g., Opcodes.H_INVOKESTATIC)
    */
-  public LambdaCallSite(String samMethodName, String samDescriptor, String indyDescriptor,
-                         String implOwner, String implName,
-                         String implDescriptor, int implTag) {
+  public LambdaCallSite(
+      String samMethodName,
+      String samDescriptor,
+      String indyDescriptor,
+      String implOwner,
+      String implName,
+      String implDescriptor,
+      int implTag) {
     this.samMethodName = samMethodName;
     this.samDescriptor = samDescriptor;
     this.indyDescriptor = indyDescriptor;
@@ -56,8 +63,8 @@ public final class LambdaCallSite {
   }
 
   /**
-   * Returns the invokedynamic call-site descriptor.
-   * The return type encodes the functional interface.
+   * Returns the invokedynamic call-site descriptor. The return type encodes the functional
+   * interface.
    *
    * @return the invokedynamic call-site descriptor
    */
@@ -104,8 +111,14 @@ public final class LambdaCallSite {
   @Override
   public String toString() {
     return "LambdaCallSite{"
-        + "sam=" + samMethodName + samDescriptor
-        + ", impl=" + implOwner + "." + implName + implDescriptor
+        + "sam="
+        + samMethodName
+        + samDescriptor
+        + ", impl="
+        + implOwner
+        + "."
+        + implName
+        + implDescriptor
         + "}";
   }
 }

--- a/src/main/java/net/cg4j/asm/MethodSignature.java
+++ b/src/main/java/net/cg4j/asm/MethodSignature.java
@@ -1,12 +1,9 @@
 package net.cg4j.asm;
 
+import java.util.Objects;
 import org.objectweb.asm.Opcodes;
 
-import java.util.Objects;
-
-/**
- * Uniquely identifies a method by its owner class, name, and descriptor.
- */
+/** Uniquely identifies a method by its owner class, name, and descriptor. */
 public final class MethodSignature {
 
   private final String owner;
@@ -104,8 +101,8 @@ public final class MethodSignature {
   }
 
   /**
-   * Formats the method as URI: owner.name:descriptor
-   * For the synthetic boot method, returns just "&lt;boot&gt;" to match WALA's convention.
+   * Formats the method as URI: owner.name:descriptor For the synthetic boot method, returns just
+   * "&lt;boot&gt;" to match WALA's convention.
    *
    * @return the formatted method URI
    */

--- a/src/main/java/net/cg4j/asm/ScopeExclusions.java
+++ b/src/main/java/net/cg4j/asm/ScopeExclusions.java
@@ -1,8 +1,5 @@
 package net.cg4j.asm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -18,13 +15,15 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Loads and applies scope exclusion patterns to filter Primordial classes from the hierarchy.
  *
- * <p>Exclusion files use one Java regex pattern per line with '/' as the package separator.
- * Lines starting with '#' are comments. Blank lines are ignored.
- * This format is compatible with WALA exclusion files.</p>
+ * <p>Exclusion files use one Java regex pattern per line with '/' as the package separator. Lines
+ * starting with '#' are comments. Blank lines are ignored. This format is compatible with WALA
+ * exclusion files.
  */
 public final class ScopeExclusions {
 
@@ -49,8 +48,8 @@ public final class ScopeExclusions {
         throw new IOException("Default exclusions resource not found: " + DEFAULT_RESOURCE);
       }
       List<String> lines;
-      try (BufferedReader reader = new BufferedReader(
-          new InputStreamReader(is, StandardCharsets.UTF_8))) {
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
         lines = reader.lines().collect(Collectors.toList());
       }
       return parseLines(lines, DEFAULT_RESOURCE);
@@ -81,9 +80,7 @@ public final class ScopeExclusions {
     return new ScopeExclusions(Collections.emptyList());
   }
 
-  /**
-   * Parses lines from an exclusion file into compiled regex patterns.
-   */
+  /** Parses lines from an exclusion file into compiled regex patterns. */
   private static ScopeExclusions parseLines(List<String> lines, String source) {
     List<Pattern> compiled = new ArrayList<>();
 
@@ -123,8 +120,8 @@ public final class ScopeExclusions {
   }
 
   /**
-   * Filters classes by removing Primordial entries that match exclusion patterns.
-   * Non-Primordial classes (Extension, Application) are never excluded.
+   * Filters classes by removing Primordial entries that match exclusion patterns. Non-Primordial
+   * classes (Extension, Application) are never excluded.
    *
    * @param classes map of class name to ClassInfo
    * @return new map with excluded Primordial classes removed

--- a/src/test/java/net/cg4j/AsmIntegrationTest.java
+++ b/src/test/java/net/cg4j/AsmIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.cg4j;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,29 +8,24 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Integration tests for the ASM-based call graph engine.
- */
+/** Integration tests for the ASM-based call graph engine. */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AsmIntegrationTest extends BaseIntegrationTest {
 
   /**
-   * Integration test: Analyzes simple library (slf4j) without Java runtime classes using ASM.
-   * RTA is more precise than CHA, producing fewer edges.
+   * Integration test: Analyzes simple library (slf4j) without Java runtime classes using ASM. RTA
+   * is more precise than CHA, producing fewer edges.
    */
   @Test
   void testAsmEngine_NoRT_Slf4j() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -45,9 +39,11 @@ class AsmIntegrationTest extends BaseIntegrationTest {
 
     // Only slf4j sources (and synthetic lambda classes derived from them)
     assertThat(TestUtils.getSourcePrefixes(outputFile))
-        .allMatch(prefix -> prefix.startsWith("org/slf4j")
-            || prefix.equals("<boot")
-            || prefix.startsWith("wala/lambda$org$slf4j"));
+        .allMatch(
+            prefix ->
+                prefix.startsWith("org/slf4j")
+                    || prefix.equals("<boot")
+                    || prefix.startsWith("wala/lambda$org$slf4j"));
   }
 
   /**
@@ -58,12 +54,9 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   void testAsmEngine_WithRT_Slf4j() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -84,13 +77,15 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   void testAsmEngine_WithDeps_NoRT_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -109,8 +104,8 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM fully covers WALA edges for slf4j without RT classes.
-   * Expects zero missing WALA edges in the ASM output.
+   * Integration test: Verifies ASM fully covers WALA edges for slf4j without RT classes. Expects
+   * zero missing WALA edges in the ASM output.
    */
   @Test
   void testAsmEngine_CoversWalaEdges_NoRT_Slf4j() throws IOException {
@@ -118,18 +113,16 @@ class AsmIntegrationTest extends BaseIntegrationTest {
     File asmOutput = TestUtils.createTempOutputFile();
 
     try {
-      int walaExitCode = TestUtils.runMain(
-          slf4jJar.getPath(),
-          "-o", walaOutput.getPath(),
-          "--engine=wala",
-          "--include-rt=false"
-      );
-      int asmExitCode = TestUtils.runMain(
-          slf4jJar.getPath(),
-          "-o", asmOutput.getPath(),
-          "--engine=asm",
-          "--include-rt=false"
-      );
+      int walaExitCode =
+          TestUtils.runMain(
+              slf4jJar.getPath(),
+              "-o",
+              walaOutput.getPath(),
+              "--engine=wala",
+              "--include-rt=false");
+      int asmExitCode =
+          TestUtils.runMain(
+              slf4jJar.getPath(), "-o", asmOutput.getPath(), "--engine=asm", "--include-rt=false");
 
       assertThat(walaExitCode).isEqualTo(0);
       assertThat(asmExitCode).isEqualTo(0);
@@ -141,8 +134,8 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM covers WALA edges for slf4j with RT classes enabled.
-   * Expects at most 1% of WALA edges to be missing from the ASM output.
+   * Integration test: Verifies ASM covers WALA edges for slf4j with RT classes enabled. Expects at
+   * most 1% of WALA edges to be missing from the ASM output.
    */
   @Test
   void testAsmEngine_CoversWalaEdges_WithRT_Slf4j() throws IOException {
@@ -150,18 +143,12 @@ class AsmIntegrationTest extends BaseIntegrationTest {
     File asmOutput = TestUtils.createTempOutputFile();
 
     try {
-      int walaExitCode = TestUtils.runMain(
-          slf4jJar.getPath(),
-          "-o", walaOutput.getPath(),
-          "--engine=wala",
-          "--include-rt=true"
-      );
-      int asmExitCode = TestUtils.runMain(
-          slf4jJar.getPath(),
-          "-o", asmOutput.getPath(),
-          "--engine=asm",
-          "--include-rt=true"
-      );
+      int walaExitCode =
+          TestUtils.runMain(
+              slf4jJar.getPath(), "-o", walaOutput.getPath(), "--engine=wala", "--include-rt=true");
+      int asmExitCode =
+          TestUtils.runMain(
+              slf4jJar.getPath(), "-o", asmOutput.getPath(), "--engine=asm", "--include-rt=true");
 
       assertThat(walaExitCode).isEqualTo(0);
       assertThat(asmExitCode).isEqualTo(0);
@@ -173,8 +160,8 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM fully covers WALA edges for OkHttp without RT classes.
-   * Expects zero missing WALA edges in the ASM output.
+   * Integration test: Verifies ASM fully covers WALA edges for OkHttp without RT classes. Expects
+   * zero missing WALA edges in the ASM output.
    */
   @Test
   void testAsmEngine_CoversWalaEdges_NoRT_OkHttp() throws IOException {
@@ -182,20 +169,24 @@ class AsmIntegrationTest extends BaseIntegrationTest {
     File asmOutput = TestUtils.createTempOutputFile();
 
     try {
-      int walaExitCode = TestUtils.runMain(
-          okhttpJar.getPath(),
-          "-d", okhttpDeps.getPath(),
-          "-o", walaOutput.getPath(),
-          "--engine=wala",
-          "--include-rt=false"
-      );
-      int asmExitCode = TestUtils.runMain(
-          okhttpJar.getPath(),
-          "-d", okhttpDeps.getPath(),
-          "-o", asmOutput.getPath(),
-          "--engine=asm",
-          "--include-rt=false"
-      );
+      int walaExitCode =
+          TestUtils.runMain(
+              okhttpJar.getPath(),
+              "-d",
+              okhttpDeps.getPath(),
+              "-o",
+              walaOutput.getPath(),
+              "--engine=wala",
+              "--include-rt=false");
+      int asmExitCode =
+          TestUtils.runMain(
+              okhttpJar.getPath(),
+              "-d",
+              okhttpDeps.getPath(),
+              "-o",
+              asmOutput.getPath(),
+              "--engine=asm",
+              "--include-rt=false");
 
       assertThat(walaExitCode).isEqualTo(0);
       assertThat(asmExitCode).isEqualTo(0);
@@ -207,8 +198,8 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM covers WALA edges for OkHttp with RT classes enabled.
-   * Expects at most 1% of WALA edges to be missing from the ASM output.
+   * Integration test: Verifies ASM covers WALA edges for OkHttp with RT classes enabled. Expects at
+   * most 1% of WALA edges to be missing from the ASM output.
    */
   @Test
   void testAsmEngine_CoversWalaEdges_WithRT_OkHttp() throws IOException {
@@ -216,20 +207,24 @@ class AsmIntegrationTest extends BaseIntegrationTest {
     File asmOutput = TestUtils.createTempOutputFile();
 
     try {
-      int walaExitCode = TestUtils.runMain(
-          okhttpJar.getPath(),
-          "-d", okhttpDeps.getPath(),
-          "-o", walaOutput.getPath(),
-          "--engine=wala",
-          "--include-rt=true"
-      );
-      int asmExitCode = TestUtils.runMain(
-          okhttpJar.getPath(),
-          "-d", okhttpDeps.getPath(),
-          "-o", asmOutput.getPath(),
-          "--engine=asm",
-          "--include-rt=true"
-      );
+      int walaExitCode =
+          TestUtils.runMain(
+              okhttpJar.getPath(),
+              "-d",
+              okhttpDeps.getPath(),
+              "-o",
+              walaOutput.getPath(),
+              "--engine=wala",
+              "--include-rt=true");
+      int asmExitCode =
+          TestUtils.runMain(
+              okhttpJar.getPath(),
+              "-d",
+              okhttpDeps.getPath(),
+              "-o",
+              asmOutput.getPath(),
+              "--engine=asm",
+              "--include-rt=true");
 
       assertThat(walaExitCode).isEqualTo(0);
       assertThat(asmExitCode).isEqualTo(0);
@@ -241,19 +236,16 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM CSV output format.
-   * Expects CSV file with correct header: "source_method,target_method".
+   * Integration test: Verifies ASM CSV output format. Expects CSV file with correct header:
+   * "source_method,target_method".
    */
   @Test
   void testAsmEngine_CSVFormat_HasCorrectHeader() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -262,19 +254,16 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM engine produces valid method URIs.
-   * Expects method URIs in format: package/Class.method:descriptor
+   * Integration test: Verifies ASM engine produces valid method URIs. Expects method URIs in
+   * format: package/Class.method:descriptor
    */
   @Test
   void testAsmEngine_MethodUriFormat() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -294,20 +283,22 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies ASM keeps synthetic lambda edges for OkHttp without RT.
-   * Expects the two-hop lambda pattern to survive no-RT filtering.
+   * Integration test: Verifies ASM keeps synthetic lambda edges for OkHttp without RT. Expects the
+   * two-hop lambda pattern to survive no-RT filtering.
    */
   @Test
   void testAsmEngine_LambdaEdges_NoRT_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(TestUtils.hasRTClasses(outputFile)).isFalse();
@@ -323,13 +314,15 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   void testAsmEngine_LambdaEdges_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -337,20 +330,23 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies fixed-point re-resolution connects virtual callers to lambda targets.
-   * Expects callers like FaultHidingSink.write to reach multiple lambda classes via dispatch.
+   * Integration test: Verifies fixed-point re-resolution connects virtual callers to lambda
+   * targets. Expects callers like FaultHidingSink.write to reach multiple lambda classes via
+   * dispatch.
    */
   @Test
   void testAsmEngine_LambdaVirtualDispatch_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -361,20 +357,20 @@ class AsmIntegrationTest extends BaseIntegrationTest {
     //   wala/lambda$okhttp3$internal$cache$DiskLruCache$0
     //   wala/lambda$okhttp3$internal$cache$DiskLruCache$Editor$0
     String faultHidingSinkWrite = "okhttp3/internal/cache/FaultHidingSink.write:";
-    List<String> lambdaTargets = edges.stream()
-        .filter(e -> e[0].startsWith(faultHidingSinkWrite))
-        .map(e -> e[1])
-        .filter(t -> t.startsWith("wala/lambda$"))
-        .collect(Collectors.toList());
+    List<String> lambdaTargets =
+        edges.stream()
+            .filter(e -> e[0].startsWith(faultHidingSinkWrite))
+            .map(e -> e[1])
+            .filter(t -> t.startsWith("wala/lambda$"))
+            .collect(Collectors.toList());
 
     assertThat(lambdaTargets)
         .as("FaultHidingSink.write should reach multiple lambda targets via virtual dispatch")
         .hasSizeGreaterThanOrEqualTo(2);
 
     // Verify at least two distinct lambda classes are targeted
-    Set<String> distinctLambdaClasses = lambdaTargets.stream()
-        .map(t -> t.substring(0, t.indexOf('.')))
-        .collect(Collectors.toSet());
+    Set<String> distinctLambdaClasses =
+        lambdaTargets.stream().map(t -> t.substring(0, t.indexOf('.'))).collect(Collectors.toSet());
 
     assertThat(distinctLambdaClasses)
         .as("FaultHidingSink.write should dispatch to at least 2 distinct lambda classes")
@@ -382,37 +378,30 @@ class AsmIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Tests error handling for invalid engine option.
-   * Expects exit code 1 (error) when invalid engine is specified.
+   * Integration test: Tests error handling for invalid engine option. Expects exit code 1 (error)
+   * when invalid engine is specified.
    */
   @Test
   void testInvalidEngine_ReturnsErrorCode() {
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "--engine=invalid"
-    );
+    int exitCode = TestUtils.runMain(slf4jJar.getPath(), "--engine=invalid");
     assertThat(exitCode).isEqualTo(1);
   }
 
   private void assertHasSyntheticLambdaEdges(List<String[]> edges) {
     // Hop 1: Some caller -> wala/lambda$...
-    boolean hasLambdaTarget = edges.stream()
-        .anyMatch(e -> e[1].startsWith("wala/lambda$"));
-    assertThat(hasLambdaTarget)
-        .as("Expected edges targeting synthetic lambda classes")
-        .isTrue();
+    boolean hasLambdaTarget = edges.stream().anyMatch(e -> e[1].startsWith("wala/lambda$"));
+    assertThat(hasLambdaTarget).as("Expected edges targeting synthetic lambda classes").isTrue();
 
     // Hop 2: wala/lambda$... -> impl method
-    boolean hasLambdaSource = edges.stream()
-        .anyMatch(e -> e[0].startsWith("wala/lambda$"));
+    boolean hasLambdaSource = edges.stream().anyMatch(e -> e[0].startsWith("wala/lambda$"));
     assertThat(hasLambdaSource)
         .as("Expected edges from synthetic lambda classes to impl methods")
         .isTrue();
   }
 
   /**
-   * Integration test: Verifies default engine is wala.
-   * Expects same behavior as explicit --engine=wala.
+   * Integration test: Verifies default engine is wala. Expects same behavior as explicit
+   * --engine=wala.
    */
   @Test
   void testDefaultEngine_IsWala() throws IOException {
@@ -422,18 +411,10 @@ class AsmIntegrationTest extends BaseIntegrationTest {
     try {
       // Run with explicit wala
       TestUtils.runMain(
-          slf4jJar.getPath(),
-          "-o", walaOutput.getPath(),
-          "--engine=wala",
-          "--include-rt=false"
-      );
+          slf4jJar.getPath(), "-o", walaOutput.getPath(), "--engine=wala", "--include-rt=false");
 
       // Run with default (no --engine)
-      TestUtils.runMain(
-          slf4jJar.getPath(),
-          "-o", defaultOutput.getPath(),
-          "--include-rt=false"
-      );
+      TestUtils.runMain(slf4jJar.getPath(), "-o", defaultOutput.getPath(), "--include-rt=false");
 
       // Both should have same edge count
       int walaEdges = TestUtils.countEdges(walaOutput);

--- a/src/test/java/net/cg4j/AsmIntegrationTest.java
+++ b/src/test/java/net/cg4j/AsmIntegrationTest.java
@@ -42,7 +42,7 @@ class AsmIntegrationTest extends BaseIntegrationTest {
         .allMatch(
             prefix ->
                 prefix.startsWith("org/slf4j")
-                    || prefix.equals("<boot")
+                    || prefix.equals("<boot>")
                     || prefix.startsWith("wala/lambda$org$slf4j"));
   }
 

--- a/src/test/java/net/cg4j/BannerTest.java
+++ b/src/test/java/net/cg4j/BannerTest.java
@@ -1,25 +1,20 @@
 package net.cg4j;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
 class BannerTest {
 
-  /**
-   * Unit test: Verifies Banner.print() completes without throwing any exception.
-   */
+  /** Unit test: Verifies Banner.print() completes without throwing any exception. */
   @Test
   void testPrint_DoesNotThrow() {
     assertThatNoException().isThrownBy(Banner::print);
   }
 
-  /**
-   * Unit test: Verifies the banner contains the CG4j tagline.
-   */
+  /** Unit test: Verifies the banner contains the CG4j tagline. */
   @Test
   void testBuildBannerLines_ContainsTagline() {
     List<String> lines = Banner.buildBannerLines();
@@ -28,9 +23,7 @@ class BannerTest {
     assertThat(output).contains("CG4j: Call Graph Generation for Java");
   }
 
-  /**
-   * Unit test: Verifies the banner contains version information.
-   */
+  /** Unit test: Verifies the banner contains version information. */
   @Test
   void testBuildBannerLines_ContainsVersion() {
     List<String> lines = Banner.buildBannerLines();
@@ -40,9 +33,7 @@ class BannerTest {
     assertThat(output).contains(version);
   }
 
-  /**
-   * Unit test: Verifies the banner contains the ASCII art logo.
-   */
+  /** Unit test: Verifies the banner contains the ASCII art logo. */
   @Test
   void testBuildBannerLines_ContainsLogo() {
     List<String> lines = Banner.buildBannerLines();
@@ -52,9 +43,7 @@ class BannerTest {
     assertThat(output).contains("/___/");
   }
 
-  /**
-   * Unit test: Verifies the banner contains the dashed box border.
-   */
+  /** Unit test: Verifies the banner contains the dashed box border. */
   @Test
   void testBuildBannerLines_ContainsBox() {
     List<String> lines = Banner.buildBannerLines();

--- a/src/test/java/net/cg4j/BaseIntegrationTest.java
+++ b/src/test/java/net/cg4j/BaseIntegrationTest.java
@@ -1,9 +1,8 @@
 package net.cg4j;
 
+import java.io.File;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-
-import java.io.File;
 
 public abstract class BaseIntegrationTest {
 

--- a/src/test/java/net/cg4j/IntegrationTest.java
+++ b/src/test/java/net/cg4j/IntegrationTest.java
@@ -1,32 +1,28 @@
 package net.cg4j;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IntegrationTest extends BaseIntegrationTest {
 
   /**
-   * Integration test: Analyzes simple library (slf4j) without Java runtime classes.
-   * Expects 746±8 edges, no RT classes, and only org/slf4j/* source prefixes.
+   * Integration test: Analyzes simple library (slf4j) without Java runtime classes. Expects 746±8
+   * edges, no RT classes, and only org/slf4j/* source prefixes.
    */
   @Test
   void testAppOnly_NoRT_Slf4j() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(slf4jJar.getPath(), "-o", outputFile.getPath(), "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -43,18 +39,15 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Analyzes simple library (slf4j) including Java runtime classes.
-   * Expects 2,721±28 edges, RT classes present, more edges than no-RT version.
+   * Integration test: Analyzes simple library (slf4j) including Java runtime classes. Expects
+   * 2,721±28 edges, RT classes present, more edges than no-RT version.
    */
   @Test
   void testAppOnly_WithRT_Slf4j() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(slf4jJar.getPath(), "-o", outputFile.getPath(), "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -70,19 +63,21 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Analyzes library with dependencies (OkHttp) without Java runtime.
-   * Expects 21,339±214 edges, no RT classes, sources from Application and Extension loaders.
+   * Integration test: Analyzes library with dependencies (OkHttp) without Java runtime. Expects
+   * 21,339±214 edges, no RT classes, sources from Application and Extension loaders.
    */
   @Test
   void testAppWithDeps_NoRT_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -95,25 +90,27 @@ class IntegrationTest extends BaseIntegrationTest {
 
     // Sources include Application and Extension loaders
     Set<String> prefixes = TestUtils.getSourcePrefixes(outputFile);
-    assertThat(prefixes).anyMatch(p -> p.startsWith("okhttp3/"));      // Application
-    assertThat(prefixes).anyMatch(p -> p.startsWith("okio/"));         // Extension
-    assertThat(prefixes).anyMatch(p -> p.startsWith("kotlin/"));       // Extension
+    assertThat(prefixes).anyMatch(p -> p.startsWith("okhttp3/")); // Application
+    assertThat(prefixes).anyMatch(p -> p.startsWith("okio/")); // Extension
+    assertThat(prefixes).anyMatch(p -> p.startsWith("kotlin/")); // Extension
   }
 
   /**
-   * Integration test: Analyzes library with dependencies (OkHttp) including Java runtime.
-   * Expects 36,131±362 edges, RT classes present, sources from all loaders.
+   * Integration test: Analyzes library with dependencies (OkHttp) including Java runtime. Expects
+   * 36,131±362 edges, RT classes present, sources from all loaders.
    */
   @Test
   void testAppWithDeps_WithRT_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -126,13 +123,13 @@ class IntegrationTest extends BaseIntegrationTest {
 
     // Sources include loaders
     Set<String> prefixes = TestUtils.getSourcePrefixes(outputFile);
-    assertThat(prefixes).anyMatch(p -> p.startsWith("okhttp3/"));  // Application
-    assertThat(prefixes).anyMatch(p -> p.startsWith("java/"));                  // Primordial
+    assertThat(prefixes).anyMatch(p -> p.startsWith("okhttp3/")); // Application
+    assertThat(prefixes).anyMatch(p -> p.startsWith("java/")); // Primordial
   }
 
   /**
-   * Integration test: Tests error handling for non-existent JAR file.
-   * Expects exit code 1 (error) when JAR file does not exist.
+   * Integration test: Tests error handling for non-existent JAR file. Expects exit code 1 (error)
+   * when JAR file does not exist.
    */
   @Test
   void testInvalidJarPath_ReturnsErrorCode() {
@@ -141,18 +138,15 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Tests custom output file path functionality.
-   * Expects file created at specified path with correct name.
+   * Integration test: Tests custom output file path functionality. Expects file created at
+   * specified path with correct name.
    */
   @Test
   void testCustomOutputFile_CreatesCorrectFile() throws IOException {
     outputFile = new File("custom-test-output.csv");
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(slf4jJar.getPath(), "-o", outputFile.getPath(), "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -160,27 +154,26 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Tests analysis without specifying dependencies flag.
-   * Expects successful execution with 746±8 edges when no -d flag provided.
+   * Integration test: Tests analysis without specifying dependencies flag. Expects successful
+   * execution with 746±8 edges when no -d flag provided.
    */
   @Test
   void testNoDepsFlag_WorksWithoutDependencies() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-        // No -d flag
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--include-rt=false"
+            // No -d flag
+            );
 
     assertThat(exitCode).isEqualTo(0);
     TestUtils.assertEdgeCount(outputFile, 746, 1.0);
   }
 
   /**
-   * Integration test: Tests handling of empty dependencies directory.
-   * Expects successful execution (exit code 0) when deps directory is empty.
+   * Integration test: Tests handling of empty dependencies directory. Expects successful execution
+   * (exit code 0) when deps directory is empty.
    */
   @Test
   void testEmptyDepsDirectory_HandlesGracefully() throws IOException {
@@ -189,30 +182,29 @@ class IntegrationTest extends BaseIntegrationTest {
 
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", emptyDir.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            emptyDir.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     // Should work but without dependency benefits
   }
 
   /**
-   * Integration test: Tests default value of --include-rt flag.
-   * Expects RT classes included by default (2,721±28 edges) when flag not specified.
+   * Integration test: Tests default value of --include-rt flag. Expects RT classes included by
+   * default (2,721±28 edges) when flag not specified.
    */
   @Test
   void testDefaultIncludeRt_IsTrue() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
     // Don't specify --include-rt flag
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath()
-    );
+    int exitCode = TestUtils.runMain(slf4jJar.getPath(), "-o", outputFile.getPath());
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -222,8 +214,8 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Tests file overwriting behavior.
-   * Expects existing output file to be overwritten with valid CSV content.
+   * Integration test: Tests file overwriting behavior. Expects existing output file to be
+   * overwritten with valid CSV content.
    */
   @Test
   void testOutputFileAlreadyExists_Overwrites() throws IOException {
@@ -233,11 +225,8 @@ class IntegrationTest extends BaseIntegrationTest {
     Files.write(outputFile.toPath(), "dummy content".getBytes());
     long originalSize = outputFile.length();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(slf4jJar.getPath(), "-o", outputFile.getPath(), "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile.length()).isNotEqualTo(originalSize);
@@ -248,18 +237,15 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Tests CSV output format validation.
-   * Expects CSV file with correct header: "source_method,target_method".
+   * Integration test: Tests CSV output format validation. Expects CSV file with correct header:
+   * "source_method,target_method".
    */
   @Test
   void testCSVFormat_HasCorrectHeader() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(slf4jJar.getPath(), "-o", outputFile.getPath(), "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -268,19 +254,21 @@ class IntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Tests entry points are only from Application ClassLoader.
-   * Expects boot edges (if any) to originate only from application code (okhttp3/*).
+   * Integration test: Tests entry points are only from Application ClassLoader. Expects boot edges
+   * (if any) to originate only from application code (okhttp3/*).
    */
   @Test
   void testEntryPointsNeverFromExtension_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
 

--- a/src/test/java/net/cg4j/QuietModeIntegrationTest.java
+++ b/src/test/java/net/cg4j/QuietModeIntegrationTest.java
@@ -1,29 +1,27 @@
 package net.cg4j;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 /**
- * Integration test for the -q/--quiet CLI option.
- * Runs cg4j as a subprocess to isolate stdout capture from parallel tests.
+ * Integration test for the -q/--quiet CLI option. Runs cg4j as a subprocess to isolate stdout
+ * capture from parallel tests.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class QuietModeIntegrationTest extends BaseIntegrationTest {
 
   /**
-   * Integration test: Verifies that -q suppresses INFO-level log output.
-   * Expects zero stdout output and a valid CSV when quiet mode is enabled.
+   * Integration test: Verifies that -q suppresses INFO-level log output. Expects zero stdout output
+   * and a valid CSV when quiet mode is enabled.
    */
   @Test
   @Disabled("Optional: requires fat JAR to be built first (mvn package)")
@@ -31,20 +29,24 @@ class QuietModeIntegrationTest extends BaseIntegrationTest {
     outputFile = TestUtils.createTempOutputFile();
 
     String jarPath = findFatJar();
-    ProcessBuilder pb = new ProcessBuilder(
-        "java", "-jar", jarPath,
-        "-q",
-        "-j", slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    ProcessBuilder pb =
+        new ProcessBuilder(
+            "java",
+            "-jar",
+            jarPath,
+            "-q",
+            "-j",
+            slf4jJar.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=false");
     pb.redirectErrorStream(true);
 
     Process process = pb.start();
     String stdout;
-    try (BufferedReader reader = new BufferedReader(
-        new InputStreamReader(process.getInputStream()))) {
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(process.getInputStream()))) {
       stdout = reader.lines().collect(Collectors.joining("\n"));
     }
 
@@ -63,15 +65,12 @@ class QuietModeIntegrationTest extends BaseIntegrationTest {
         .isEmpty();
   }
 
-  /**
-   * Locates the fat JAR (jar-with-dependencies) in the target directory.
-   */
+  /** Locates the fat JAR (jar-with-dependencies) in the target directory. */
   private static String findFatJar() throws IOException {
     File targetDir = new File("target");
     assertThat(targetDir).exists();
 
-    File[] jars = targetDir.listFiles(
-        (dir, name) -> name.endsWith("-jar-with-dependencies.jar"));
+    File[] jars = targetDir.listFiles((dir, name) -> name.endsWith("-jar-with-dependencies.jar"));
     assertThat(jars)
         .as("Expected fat JAR in target/. Run 'mvn package' first.")
         .isNotNull()

--- a/src/test/java/net/cg4j/RtaIntegrationTest.java
+++ b/src/test/java/net/cg4j/RtaIntegrationTest.java
@@ -1,19 +1,15 @@
 package net.cg4j;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Integration tests for the RTA (Rapid Type Analysis) algorithm.
- */
+/** Integration tests for the RTA (Rapid Type Analysis) algorithm. */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RtaIntegrationTest extends BaseIntegrationTest {
 
@@ -25,12 +21,9 @@ class RtaIntegrationTest extends BaseIntegrationTest {
   void testRtaEngine_NoRT_Slf4j() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -44,9 +37,11 @@ class RtaIntegrationTest extends BaseIntegrationTest {
 
     // Only slf4j sources (and synthetic lambda classes derived from them)
     assertThat(TestUtils.getSourcePrefixes(outputFile))
-        .allMatch(prefix -> prefix.startsWith("org/slf4j")
-            || prefix.equals("<boot")
-            || prefix.startsWith("wala/lambda$org$slf4j"));
+        .allMatch(
+            prefix ->
+                prefix.startsWith("org/slf4j")
+                    || prefix.equals("<boot")
+                    || prefix.startsWith("wala/lambda$org$slf4j"));
   }
 
   /**
@@ -57,12 +52,9 @@ class RtaIntegrationTest extends BaseIntegrationTest {
   void testRtaEngine_WithRT_Slf4j() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -83,13 +75,15 @@ class RtaIntegrationTest extends BaseIntegrationTest {
   void testRtaEngine_WithDeps_OkHttp() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
     assertThat(outputFile).exists();
@@ -107,19 +101,16 @@ class RtaIntegrationTest extends BaseIntegrationTest {
   }
 
   /**
-   * Integration test: Verifies RTA CSV output format.
-   * Expects CSV file with correct header: "source_method,target_method".
+   * Integration test: Verifies RTA CSV output format. Expects CSV file with correct header:
+   * "source_method,target_method".
    */
   @Test
   void testRtaEngine_CSVFormat_HasCorrectHeader() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
 
@@ -135,46 +126,40 @@ class RtaIntegrationTest extends BaseIntegrationTest {
   void testRtaEngine_ProducesClinitEdges() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        okhttpJar.getPath(),
-        "-d", okhttpDeps.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=true"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            okhttpJar.getPath(),
+            "-d",
+            okhttpDeps.getPath(),
+            "-o",
+            outputFile.getPath(),
+            "--engine=asm",
+            "--include-rt=true");
 
     assertThat(exitCode).isEqualTo(0);
 
     List<String[]> edges = TestUtils.parseCSV(outputFile);
-    boolean hasClinitEdge = edges.stream()
-        .anyMatch(e -> e[0].equals("<boot>") && e[1].contains("<clinit>"));
-    assertThat(hasClinitEdge)
-        .as("Expected <boot> -> <clinit> edges in output")
-        .isTrue();
+    boolean hasClinitEdge =
+        edges.stream().anyMatch(e -> e[0].equals("<boot>") && e[1].contains("<clinit>"));
+    assertThat(hasClinitEdge).as("Expected <boot> -> <clinit> edges in output").isTrue();
   }
 
   /**
-   * Integration test: Verifies no-RT output filters boot edges like WALA.
-   * Expects no {@code <boot> -> *} edges when RT is excluded.
+   * Integration test: Verifies no-RT output filters boot edges like WALA. Expects no {@code <boot>
+   * -> *} edges when RT is excluded.
    */
   @Test
   void testRtaEngine_NoRtFiltersBootEdges() throws IOException {
     outputFile = TestUtils.createTempOutputFile();
 
-    int exitCode = TestUtils.runMain(
-        slf4jJar.getPath(),
-        "-o", outputFile.getPath(),
-        "--engine=asm",
-        "--include-rt=false"
-    );
+    int exitCode =
+        TestUtils.runMain(
+            slf4jJar.getPath(), "-o", outputFile.getPath(), "--engine=asm", "--include-rt=false");
 
     assertThat(exitCode).isEqualTo(0);
 
     List<String[]> edges = TestUtils.parseCSV(outputFile);
-    boolean hasBootEdges = edges.stream()
-        .anyMatch(e -> e[0].equals("<boot>"));
-    assertThat(hasBootEdges)
-        .as("Expected no <boot> edges when RT is excluded")
-        .isFalse();
+    boolean hasBootEdges = edges.stream().anyMatch(e -> e[0].equals("<boot>"));
+    assertThat(hasBootEdges).as("Expected no <boot> edges when RT is excluded").isFalse();
   }
 }

--- a/src/test/java/net/cg4j/RtaIntegrationTest.java
+++ b/src/test/java/net/cg4j/RtaIntegrationTest.java
@@ -40,7 +40,7 @@ class RtaIntegrationTest extends BaseIntegrationTest {
         .allMatch(
             prefix ->
                 prefix.startsWith("org/slf4j")
-                    || prefix.equals("<boot")
+                    || prefix.equals("<boot>")
                     || prefix.startsWith("wala/lambda$org$slf4j"));
   }
 

--- a/src/test/java/net/cg4j/TestUtils.java
+++ b/src/test/java/net/cg4j/TestUtils.java
@@ -1,7 +1,5 @@
 package net.cg4j;
 
-import picocli.CommandLine;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -12,12 +10,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import picocli.CommandLine;
 
 public class TestUtils {
 
-  /**
-   * Get test JAR file from resources
-   */
+  /** Get test JAR file from resources */
   public static File getTestJar(String filename) {
     try {
       return new File(TestUtils.class.getResource("/test-jars/" + filename).toURI());
@@ -26,9 +23,7 @@ public class TestUtils {
     }
   }
 
-  /**
-   * Get test deps directory
-   */
+  /** Get test deps directory */
   public static File getTestDepsDir() {
     try {
       return new File(TestUtils.class.getResource("/test-jars/deps").toURI());
@@ -37,9 +32,7 @@ public class TestUtils {
     }
   }
 
-  /**
-   * Parse CSV file and return list of edges [source, target]
-   */
+  /** Parse CSV file and return list of edges [source, target] */
   public static List<String[]> parseCSV(File csvFile) throws IOException {
     List<String[]> edges = new ArrayList<>();
     try (BufferedReader reader = Files.newBufferedReader(csvFile.toPath())) {
@@ -52,34 +45,26 @@ public class TestUtils {
     return edges;
   }
 
-  /**
-   * Count total edges in CSV (excluding header)
-   */
+  /** Count total edges in CSV (excluding header) */
   public static int countEdges(File csvFile) throws IOException {
     return parseCSV(csvFile).size();
   }
 
-  /**
-   * Parse CSV file and return a de-duplicated edge set.
-   */
+  /** Parse CSV file and return a de-duplicated edge set. */
   public static Set<String> parseEdgeSet(File csvFile) throws IOException {
     return parseCSV(csvFile).stream()
         .map(edge -> edge[0] + "," + edge[1])
         .collect(Collectors.toCollection(HashSet::new));
   }
 
-  /**
-   * Check if CSV contains java/* classes in sources or targets
-   */
+  /** Check if CSV contains java/* classes in sources or targets */
   public static boolean hasRTClasses(File csvFile) throws IOException {
     List<String[]> edges = parseCSV(csvFile);
-    return edges.stream().anyMatch(edge ->
-        edge[0].startsWith("java/") || edge[1].startsWith("java/"));
+    return edges.stream()
+        .anyMatch(edge -> edge[0].startsWith("java/") || edge[1].startsWith("java/"));
   }
 
-  /**
-   * Get unique source package prefixes (first 2 segments)
-   */
+  /** Get unique source package prefixes (first 2 segments) */
   public static Set<String> getSourcePrefixes(File csvFile) throws IOException {
     List<String[]> edges = parseCSV(csvFile);
     Set<String> prefixes = new HashSet<>();
@@ -95,18 +80,14 @@ public class TestUtils {
     return prefixes;
   }
 
-  /**
-   * Create temporary output file for test
-   */
+  /** Create temporary output file for test */
   public static File createTempOutputFile() throws IOException {
     File tempFile = File.createTempFile("test-cg-", ".csv");
     tempFile.deleteOnExit();
     return tempFile;
   }
 
-  /**
-   * Delete file if exists
-   */
+  /** Delete file if exists */
   public static void cleanupFile(File file) {
     if (file != null && file.exists()) {
       file.delete();
@@ -115,28 +96,26 @@ public class TestUtils {
 
   /**
    * Run Main programmatically without System.exit()
-   * 
-   * First argument is treated as JAR path and automatically prefixed with -j flag.
-   * Example: runMain("app.jar", "-o", "out.csv") -> executes with args: ["-j", "app.jar", "-o", "out.csv"]
+   *
+   * <p>First argument is treated as JAR path and automatically prefixed with -j flag. Example:
+   * runMain("app.jar", "-o", "out.csv") -> executes with args: ["-j", "app.jar", "-o", "out.csv"]
    */
   public static int runMain(String... args) {
     if (args.length == 0) {
       throw new IllegalArgumentException("runMain requires at least one argument (JAR path)");
     }
-    
+
     // Prepend -j flag before the first argument (JAR path)
     String[] newArgs = new String[args.length + 1];
     newArgs[0] = "-j";
     System.arraycopy(args, 0, newArgs, 1, args.length);
-    
+
     Main main = new Main();
     CommandLine cmd = new CommandLine(main);
     return cmd.execute(newArgs);
   }
 
-  /**
-   * Assert edge count is within tolerance
-   */
+  /** Assert edge count is within tolerance */
   public static void assertEdgeCount(File csv, int expected, double tolerancePercent)
       throws IOException {
     int actual = countEdges(csv);
@@ -145,15 +124,14 @@ public class TestUtils {
     int max = expected + tolerance;
 
     if (actual < min || actual > max) {
-      throw new AssertionError(String.format(
-          "Edge count %d not within %d±%d (%.1f%% tolerance)",
-          actual, expected, tolerance, tolerancePercent));
+      throw new AssertionError(
+          String.format(
+              "Edge count %d not within %d±%d (%.1f%% tolerance)",
+              actual, expected, tolerance, tolerancePercent));
     }
   }
 
-  /**
-   * Assert that ASM covers WALA's edge set within the allowed missing percentage.
-   */
+  /** Assert that ASM covers WALA's edge set within the allowed missing percentage. */
   public static void assertWalaEdgeCoverage(File walaCsv, File asmCsv, double allowedMissingPercent)
       throws IOException {
     Set<String> walaEdges = parseEdgeSet(walaCsv);
@@ -164,13 +142,12 @@ public class TestUtils {
 
     int allowedMissing = (int) Math.ceil(walaEdges.size() * allowedMissingPercent / 100.0);
     if (missingEdges.size() > allowedMissing) {
-      List<String> sampleMissing = missingEdges.stream()
-          .sorted()
-          .limit(10)
-          .collect(Collectors.toList());
-      throw new AssertionError(String.format(
-          "Missing %d WALA edges (allowed %d, %.2f%% tolerance). Sample: %s",
-          missingEdges.size(), allowedMissing, allowedMissingPercent, sampleMissing));
+      List<String> sampleMissing =
+          missingEdges.stream().sorted().limit(10).collect(Collectors.toList());
+      throw new AssertionError(
+          String.format(
+              "Missing %d WALA edges (allowed %d, %.2f%% tolerance). Sample: %s",
+              missingEdges.size(), allowedMissing, allowedMissingPercent, sampleMissing));
     }
   }
 }

--- a/src/test/java/net/cg4j/WalaCallGraphBuilderTest.java
+++ b/src/test/java/net/cg4j/WalaCallGraphBuilderTest.java
@@ -1,18 +1,17 @@
 package net.cg4j;
 
-import com.ibm.wala.ipa.callgraph.CallGraph;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.ibm.wala.ipa.callgraph.CallGraph;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WalaCallGraphBuilderTest extends BaseIntegrationTest {
@@ -25,72 +24,55 @@ class WalaCallGraphBuilderTest extends BaseIntegrationTest {
   }
 
   /**
-   * Tests basic call graph construction from a simple JAR file.
-   * Expects non-null call graph with at least one node.
+   * Tests basic call graph construction from a simple JAR file. Expects non-null call graph with at
+   * least one node.
    */
   @Test
   void testBuildCallGraph_ValidJar_Success() throws Exception {
-    CallGraph cg = builder.buildCallGraph(
-        slf4jJar.getPath(),
-        Collections.emptyList(),
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(slf4jJar.getPath(), Collections.emptyList(), null);
 
     assertThat(cg).isNotNull();
     assertThat(cg.getNumberOfNodes()).isGreaterThan(0);
   }
 
   /**
-   * Tests call graph construction with dependency JARs loaded via Extension ClassLoader.
-   * Expects larger call graph (1000+ nodes) when dependencies are included.
+   * Tests call graph construction with dependency JARs loaded via Extension ClassLoader. Expects
+   * larger call graph (1000+ nodes) when dependencies are included.
    */
   @Test
   void testBuildCallGraph_WithDependencies_LoadsExtension() throws Exception {
     List<File> deps = Arrays.asList(okhttpDeps.listFiles());
 
-    CallGraph cg = builder.buildCallGraph(
-        okhttpJar.getPath(),
-        deps,
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(okhttpJar.getPath(), deps, null);
 
     assertThat(cg).isNotNull();
     assertThat(cg.getNumberOfNodes()).isGreaterThan(1000);
   }
 
-  /**
-   * Tests error handling when JAR file does not exist.
-   * Expects exception to be thrown.
-   */
+  /** Tests error handling when JAR file does not exist. Expects exception to be thrown. */
   @Test
   void testBuildCallGraph_NonExistentJar_ThrowsException() {
-    assertThatThrownBy(() -> {
-      builder.buildCallGraph(
-          "nonexistent.jar",
-          Collections.emptyList(),
-          null
-      );
-    }).isInstanceOf(Throwable.class);
+    assertThatThrownBy(
+            () -> {
+              builder.buildCallGraph("nonexistent.jar", Collections.emptyList(), null);
+            })
+        .isInstanceOf(Throwable.class);
   }
 
   /**
-   * Unit test: Tests stream-based edge extraction returns edges.
-   * Expects at least one edge with non-empty source and target.
+   * Unit test: Tests stream-based edge extraction returns edges. Expects at least one edge with
+   * non-empty source and target.
    */
   @Test
   void testExtractEdgesAsStream_ReturnsNonEmptyStream() throws Exception {
-    CallGraph cg = builder.buildCallGraph(
-        slf4jJar.getPath(),
-        Collections.emptyList(),
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(slf4jJar.getPath(), Collections.emptyList(), null);
 
     Stream<WalaCallGraphBuilder.CallGraphEdge> edges =
         WalaCallGraphBuilder.extractEdgesAsStream(cg, false);
 
-    WalaCallGraphBuilder.CallGraphEdge edge = edges.findFirst()
-        .orElseThrow(() -> new AssertionError("Expected at least one edge"));
-    
+    WalaCallGraphBuilder.CallGraphEdge edge =
+        edges.findFirst().orElseThrow(() -> new AssertionError("Expected at least one edge"));
+
     assertThat(edge.source).isNotEmpty();
     assertThat(edge.target).isNotEmpty();
     assertThat(edge.source).contains(".");
@@ -98,66 +80,52 @@ class WalaCallGraphBuilderTest extends BaseIntegrationTest {
   }
 
   /**
-   * Tests RT (Java runtime) class filtering when disabled.
-   * Expects no java/* classes in extracted edges when includeRT=false.
+   * Tests RT (Java runtime) class filtering when disabled. Expects no java/* classes in extracted
+   * edges when includeRT=false.
    */
   @Test
   void testExtractEdgesAsStream_FiltersRTWhenDisabled() throws Exception {
-    CallGraph cg = builder.buildCallGraph(
-        slf4jJar.getPath(),
-        Collections.emptyList(),
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(slf4jJar.getPath(), Collections.emptyList(), null);
 
     Stream<WalaCallGraphBuilder.CallGraphEdge> edges =
         WalaCallGraphBuilder.extractEdgesAsStream(cg, false);
 
-    boolean hasRTEdge = edges.anyMatch(edge -> 
-        edge.source.startsWith("java/") || edge.target.startsWith("java/")
-    );
+    boolean hasRTEdge =
+        edges.anyMatch(edge -> edge.source.startsWith("java/") || edge.target.startsWith("java/"));
 
     assertThat(hasRTEdge).isFalse();
   }
 
   /**
-   * Tests RT (Java runtime) class inclusion when enabled.
-   * Expects at least one java/* class in extracted edges when includeRT=true.
+   * Tests RT (Java runtime) class inclusion when enabled. Expects at least one java/* class in
+   * extracted edges when includeRT=true.
    */
   @Test
   void testExtractEdgesAsStream_IncludesRTWhenEnabled() throws Exception {
-    CallGraph cg = builder.buildCallGraph(
-        slf4jJar.getPath(),
-        Collections.emptyList(),
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(slf4jJar.getPath(), Collections.emptyList(), null);
 
     Stream<WalaCallGraphBuilder.CallGraphEdge> edges =
         WalaCallGraphBuilder.extractEdgesAsStream(cg, true);
 
-    boolean foundRTEdge = edges.anyMatch(edge -> 
-        edge.source.startsWith("java/") || edge.target.startsWith("java/")
-    );
+    boolean foundRTEdge =
+        edges.anyMatch(edge -> edge.source.startsWith("java/") || edge.target.startsWith("java/"));
 
     assertThat(foundRTEdge).isTrue();
   }
 
   /**
-   * Tests method signature formatting.
-   * Expects format: package.Class.method:(descriptor) with package, class, method, and descriptor.
+   * Tests method signature formatting. Expects format: package.Class.method:(descriptor) with
+   * package, class, method, and descriptor.
    */
   @Test
   void testFormatMethod_ReturnsCorrectSignature() throws Exception {
-    CallGraph cg = builder.buildCallGraph(
-        slf4jJar.getPath(),
-        Collections.emptyList(),
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(slf4jJar.getPath(), Collections.emptyList(), null);
 
     Stream<WalaCallGraphBuilder.CallGraphEdge> edges =
         WalaCallGraphBuilder.extractEdgesAsStream(cg, false);
 
-    WalaCallGraphBuilder.CallGraphEdge edge = edges.findFirst()
-        .orElseThrow(() -> new AssertionError("Expected at least one edge"));
+    WalaCallGraphBuilder.CallGraphEdge edge =
+        edges.findFirst().orElseThrow(() -> new AssertionError("Expected at least one edge"));
 
     // Verify format: contains package, class, method, and descriptor
     assertThat(edge.source).matches(".+\\..+:.+");
@@ -165,18 +133,14 @@ class WalaCallGraphBuilderTest extends BaseIntegrationTest {
   }
 
   /**
-   * Tests entry points are generated only from Application ClassLoader.
-   * Expects non-null call graph with entry points from application code only.
+   * Tests entry points are generated only from Application ClassLoader. Expects non-null call graph
+   * with entry points from application code only.
    */
   @Test
   void testEntryPoints_OnlyApplicationLoader() throws Exception {
     List<File> deps = Arrays.asList(okhttpDeps.listFiles());
 
-    CallGraph cg = builder.buildCallGraph(
-        okhttpJar.getPath(),
-        deps,
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(okhttpJar.getPath(), deps, null);
 
     // Verify call graph was built successfully
     // Entry points validation is indirect - verified in integration tests
@@ -185,16 +149,12 @@ class WalaCallGraphBuilderTest extends BaseIntegrationTest {
   }
 
   /**
-   * Tests call graph construction with no dependencies.
-   * Expects successful graph construction when dependency list is empty.
+   * Tests call graph construction with no dependencies. Expects successful graph construction when
+   * dependency list is empty.
    */
   @Test
   void testEmptyDependenciesList_Works() throws Exception {
-    CallGraph cg = builder.buildCallGraph(
-        slf4jJar.getPath(),
-        Collections.emptyList(),
-        null
-    );
+    CallGraph cg = builder.buildCallGraph(slf4jJar.getPath(), Collections.emptyList(), null);
 
     assertThat(cg).isNotNull();
     assertThat(cg.getNumberOfNodes()).isGreaterThan(0);

--- a/src/test/java/net/cg4j/asm/CallGraphResultTest.java
+++ b/src/test/java/net/cg4j/asm/CallGraphResultTest.java
@@ -1,17 +1,15 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Unit tests for CallGraphResult class.
- */
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for CallGraphResult class. */
 class CallGraphResultTest {
 
   /**
-   * Unit test: Tests CallGraphResult.Edge storage.
-   * Expects correct source and target method signatures in edge.
+   * Unit test: Tests CallGraphResult.Edge storage. Expects correct source and target method
+   * signatures in edge.
    */
   @Test
   void testEdgeStorage() {
@@ -27,8 +25,8 @@ class CallGraphResultTest {
   }
 
   /**
-   * Unit test: Tests CallGraphResult.Edge equality.
-   * Expects edges with same source and target to be equal.
+   * Unit test: Tests CallGraphResult.Edge equality. Expects edges with same source and target to be
+   * equal.
    */
   @Test
   void testEdgeEquality() {

--- a/src/test/java/net/cg4j/asm/CallSiteExtractorTest.java
+++ b/src/test/java/net/cg4j/asm/CallSiteExtractorTest.java
@@ -1,26 +1,23 @@
 package net.cg4j.asm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.ClassReader;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Unit tests for CallSiteExtractor class.
- */
+/** Unit tests for CallSiteExtractor class. */
 class CallSiteExtractorTest {
 
   /**
-   * Unit test: Tests CallSiteExtractor tracking of NEW instructions.
-   * Expects NEW instructions to be tracked as instantiated types.
+   * Unit test: Tests CallSiteExtractor tracking of NEW instructions. Expects NEW instructions to be
+   * tracked as instantiated types.
    */
   @Test
   void testTracksInstantiatedTypes() {
@@ -39,15 +36,16 @@ class CallSiteExtractorTest {
   }
 
   /**
-   * Unit test: Tests CallSiteExtractor tracking of static field accesses.
-   * Expects GETSTATIC and PUTSTATIC owners to be recorded once.
+   * Unit test: Tests CallSiteExtractor tracking of static field accesses. Expects GETSTATIC and
+   * PUTSTATIC owners to be recorded once.
    */
   @Test
   void testTracksStaticFieldOwners() {
     CallSiteExtractor extractor = new CallSiteExtractor();
 
     extractor.visitFieldInsn(Opcodes.GETSTATIC, "com/example/Config", "VALUE", "I");
-    extractor.visitFieldInsn(Opcodes.PUTSTATIC, "com/example/Holder", "CACHE", "Ljava/lang/Object;");
+    extractor.visitFieldInsn(
+        Opcodes.PUTSTATIC, "com/example/Holder", "CACHE", "Ljava/lang/Object;");
     extractor.visitFieldInsn(Opcodes.GETFIELD, "com/example/Instance", "field", "I");
 
     assertThat(extractor.getStaticFieldOwners())
@@ -55,18 +53,22 @@ class CallSiteExtractorTest {
   }
 
   /**
-   * Unit test: Tests extraction of LambdaMetafactory INVOKEDYNAMIC instructions.
-   * Expects lambda call sites to be captured with correct SAM and impl info.
+   * Unit test: Tests extraction of LambdaMetafactory INVOKEDYNAMIC instructions. Expects lambda
+   * call sites to be captured with correct SAM and impl info.
    */
   @Test
   void testExtractsLambdaMetafactory() {
-    byte[] bytecode = buildClassWithLambda(
-        "java/lang/invoke/LambdaMetafactory", "metafactory",
-        "run", "()V",
-        "com/example/MyClass", "lambda$test$0", "()V",
-        Opcodes.H_INVOKESTATIC,
-        "()Ljava/lang/Runnable;"
-    );
+    byte[] bytecode =
+        buildClassWithLambda(
+            "java/lang/invoke/LambdaMetafactory",
+            "metafactory",
+            "run",
+            "()V",
+            "com/example/MyClass",
+            "lambda$test$0",
+            "()V",
+            Opcodes.H_INVOKESTATIC,
+            "()Ljava/lang/Runnable;");
 
     CallSiteExtractor extractor = visitMethod(bytecode, "testMethod", "()V");
 
@@ -87,46 +89,49 @@ class CallSiteExtractorTest {
   }
 
   /**
-   * Unit test: Tests that non-LambdaMetafactory INVOKEDYNAMIC is ignored.
-   * Expects no lambda call sites for StringConcatFactory bootstrap.
+   * Unit test: Tests that non-LambdaMetafactory INVOKEDYNAMIC is ignored. Expects no lambda call
+   * sites for StringConcatFactory bootstrap.
    */
   @Test
   void testIgnoresNonLambdaInvokeDynamic() {
     CallSiteExtractor extractor = new CallSiteExtractor();
 
     // Simulate StringConcatFactory.makeConcatWithConstants (Java 9+ string concat)
-    Handle bootstrap = new Handle(
-        Opcodes.H_INVOKESTATIC,
-        "java/lang/invoke/StringConcatFactory",
-        "makeConcatWithConstants",
-        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
-            + "Ljava/lang/invoke/MethodType;Ljava/lang/String;"
-            + "[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;",
-        false
-    );
+    Handle bootstrap =
+        new Handle(
+            Opcodes.H_INVOKESTATIC,
+            "java/lang/invoke/StringConcatFactory",
+            "makeConcatWithConstants",
+            "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
+                + "Ljava/lang/invoke/MethodType;Ljava/lang/String;"
+                + "[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;",
+            false);
     extractor.visitInvokeDynamicInsn(
         "makeConcatWithConstants",
         "(Ljava/lang/String;)Ljava/lang/String;",
         bootstrap,
-        "\u0001 world"
-    );
+        "\u0001 world");
 
     assertThat(extractor.getLambdaCallSites()).isEmpty();
   }
 
   /**
-   * Unit test: Tests extraction of altMetafactory INVOKEDYNAMIC instructions.
-   * Expects lambda call sites to be captured for altMetafactory bootstrap.
+   * Unit test: Tests extraction of altMetafactory INVOKEDYNAMIC instructions. Expects lambda call
+   * sites to be captured for altMetafactory bootstrap.
    */
   @Test
   void testAltMetafactory() {
-    byte[] bytecode = buildClassWithLambda(
-        "java/lang/invoke/LambdaMetafactory", "altMetafactory",
-        "apply", "(Ljava/lang/Object;)Ljava/lang/Object;",
-        "com/example/MyClass", "lambda$map$0", "(Ljava/lang/String;)Ljava/lang/Integer;",
-        Opcodes.H_INVOKESTATIC,
-        "()Ljava/util/function/Function;"
-    );
+    byte[] bytecode =
+        buildClassWithLambda(
+            "java/lang/invoke/LambdaMetafactory",
+            "altMetafactory",
+            "apply",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            "com/example/MyClass",
+            "lambda$map$0",
+            "(Ljava/lang/String;)Ljava/lang/Integer;",
+            Opcodes.H_INVOKESTATIC,
+            "()Ljava/util/function/Function;");
 
     CallSiteExtractor extractor = visitMethod(bytecode, "testMethod", "()V");
 
@@ -137,14 +142,14 @@ class CallSiteExtractorTest {
   }
 
   /**
-   * Unit test: Tests that both regular call sites and lambda call sites are captured.
-   * Expects both lists to be populated independently.
+   * Unit test: Tests that both regular call sites and lambda call sites are captured. Expects both
+   * lists to be populated independently.
    */
   @Test
   void testLambdaAndRegularCallSites() {
     ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-    cw.visit(Opcodes.V11, Opcodes.ACC_PUBLIC, "com/example/TestClass", null,
-        "java/lang/Object", null);
+    cw.visit(
+        Opcodes.V11, Opcodes.ACC_PUBLIC, "com/example/TestClass", null, "java/lang/Object", null);
 
     MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "testMethod", "()V", null, null);
     mv.visitCode();
@@ -153,31 +158,26 @@ class CallSiteExtractorTest {
     mv.visitMethodInsn(Opcodes.INVOKESTATIC, "com/example/Helper", "doWork", "()V", false);
 
     // Lambda INVOKEDYNAMIC
-    Handle bootstrap = new Handle(
-        Opcodes.H_INVOKESTATIC,
-        "java/lang/invoke/LambdaMetafactory",
-        "metafactory",
-        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
-            + "Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;"
-            + "Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;"
-            + ")Ljava/lang/invoke/CallSite;",
-        false
-    );
-    Handle implHandle = new Handle(
-        Opcodes.H_INVOKESTATIC,
-        "com/example/TestClass",
-        "lambda$testMethod$0",
-        "()V",
-        false
-    );
+    Handle bootstrap =
+        new Handle(
+            Opcodes.H_INVOKESTATIC,
+            "java/lang/invoke/LambdaMetafactory",
+            "metafactory",
+            "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
+                + "Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;"
+                + "Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;"
+                + ")Ljava/lang/invoke/CallSite;",
+            false);
+    Handle implHandle =
+        new Handle(
+            Opcodes.H_INVOKESTATIC, "com/example/TestClass", "lambda$testMethod$0", "()V", false);
     mv.visitInvokeDynamicInsn(
         "run",
         "()Ljava/lang/Runnable;",
         bootstrap,
         Type.getType("()V"),
         implHandle,
-        Type.getType("()V")
-    );
+        Type.getType("()V"));
 
     mv.visitInsn(Opcodes.RETURN);
     mv.visitMaxs(1, 1);
@@ -190,48 +190,56 @@ class CallSiteExtractorTest {
     assertThat(extractor.getCallSites().get(0).getOwner()).isEqualTo("com/example/Helper");
 
     assertThat(extractor.getLambdaCallSites()).hasSize(1);
-    assertThat(extractor.getLambdaCallSites().get(0).getImplOwner()).isEqualTo("com/example/TestClass");
+    assertThat(extractor.getLambdaCallSites().get(0).getImplOwner())
+        .isEqualTo("com/example/TestClass");
   }
 
   /**
-   * Unit test: Tests that LambdaMetafactory calls via visitMethodInsn are still skipped.
-   * Expects no regular call site for LambdaMetafactory owner.
+   * Unit test: Tests that LambdaMetafactory calls via visitMethodInsn are still skipped. Expects no
+   * regular call site for LambdaMetafactory owner.
    */
   @Test
   void testSkipsLambdaMetafactoryMethodInsn() {
     CallSiteExtractor extractor = new CallSiteExtractor();
 
-    extractor.visitMethodInsn(Opcodes.INVOKESTATIC,
-        "java/lang/invoke/LambdaMetafactory", "metafactory",
-        "(Ljava/lang/invoke/MethodHandles$Lookup;)Ljava/lang/invoke/CallSite;", false);
+    extractor.visitMethodInsn(
+        Opcodes.INVOKESTATIC,
+        "java/lang/invoke/LambdaMetafactory",
+        "metafactory",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;)Ljava/lang/invoke/CallSite;",
+        false);
 
     assertThat(extractor.getCallSites()).isEmpty();
   }
 
-  /**
-   * Builds a class with a method containing an INVOKEDYNAMIC instruction.
-   */
-  private static byte[] buildClassWithLambda(String bootstrapOwner, String bootstrapName,
-                                             String samName, String samDesc,
-                                             String implOwner, String implName, String implDesc,
-                                             int implTag, String indyDescriptor) {
+  /** Builds a class with a method containing an INVOKEDYNAMIC instruction. */
+  private static byte[] buildClassWithLambda(
+      String bootstrapOwner,
+      String bootstrapName,
+      String samName,
+      String samDesc,
+      String implOwner,
+      String implName,
+      String implDesc,
+      int implTag,
+      String indyDescriptor) {
     ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-    cw.visit(Opcodes.V11, Opcodes.ACC_PUBLIC, "com/example/TestClass", null,
-        "java/lang/Object", null);
+    cw.visit(
+        Opcodes.V11, Opcodes.ACC_PUBLIC, "com/example/TestClass", null, "java/lang/Object", null);
 
     MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "testMethod", "()V", null, null);
     mv.visitCode();
 
-    Handle bootstrap = new Handle(
-        Opcodes.H_INVOKESTATIC,
-        bootstrapOwner,
-        bootstrapName,
-        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
-            + "Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;"
-            + "Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;"
-            + ")Ljava/lang/invoke/CallSite;",
-        false
-    );
+    Handle bootstrap =
+        new Handle(
+            Opcodes.H_INVOKESTATIC,
+            bootstrapOwner,
+            bootstrapName,
+            "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
+                + "Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;"
+                + "Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;"
+                + ")Ljava/lang/invoke/CallSite;",
+            false);
     Handle implHandle = new Handle(implTag, implOwner, implName, implDesc, false);
 
     mv.visitInvokeDynamicInsn(
@@ -240,8 +248,7 @@ class CallSiteExtractorTest {
         bootstrap,
         Type.getType(samDesc),
         implHandle,
-        Type.getType(samDesc)
-    );
+        Type.getType(samDesc));
 
     mv.visitInsn(Opcodes.RETURN);
     mv.visitMaxs(1, 1);
@@ -251,23 +258,23 @@ class CallSiteExtractorTest {
     return cw.toByteArray();
   }
 
-  /**
-   * Visits a specific method in bytecode and returns the extractor with results.
-   */
-  private static CallSiteExtractor visitMethod(byte[] bytecode, String methodName,
-                                               String descriptor) {
+  /** Visits a specific method in bytecode and returns the extractor with results. */
+  private static CallSiteExtractor visitMethod(
+      byte[] bytecode, String methodName, String descriptor) {
     CallSiteExtractor extractor = new CallSiteExtractor();
     ClassReader reader = new ClassReader(bytecode);
-    reader.accept(new org.objectweb.asm.ClassVisitor(Opcodes.ASM9) {
-      @Override
-      public MethodVisitor visitMethod(int access, String name, String desc,
-                                       String signature, String[] exceptions) {
-        if (name.equals(methodName) && desc.equals(descriptor)) {
-          return extractor;
-        }
-        return null;
-      }
-    }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+    reader.accept(
+        new org.objectweb.asm.ClassVisitor(Opcodes.ASM9) {
+          @Override
+          public MethodVisitor visitMethod(
+              int access, String name, String desc, String signature, String[] exceptions) {
+            if (name.equals(methodName) && desc.equals(descriptor)) {
+              return extractor;
+            }
+            return null;
+          }
+        },
+        ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
     return extractor;
   }
 }

--- a/src/test/java/net/cg4j/asm/CallSiteTest.java
+++ b/src/test/java/net/cg4j/asm/CallSiteTest.java
@@ -1,25 +1,27 @@
 package net.cg4j.asm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Unit tests for CallSite class.
- */
+/** Unit tests for CallSite class. */
 class CallSiteTest {
 
   /**
-   * Unit test: Tests CallSite properties for different opcodes.
-   * Expects correct identification of static, virtual, special, and interface calls.
+   * Unit test: Tests CallSite properties for different opcodes. Expects correct identification of
+   * static, virtual, special, and interface calls.
    */
   @Test
   void testOpcodeTypes() {
-    CallSite staticCall = new CallSite(Opcodes.INVOKESTATIC, "java/lang/Math", "abs", "(I)I", false);
-    CallSite virtualCall = new CallSite(Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
-    CallSite interfaceCall = new CallSite(Opcodes.INVOKEINTERFACE, "java/util/List", "size", "()I", true);
-    CallSite specialCall = new CallSite(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+    CallSite staticCall =
+        new CallSite(Opcodes.INVOKESTATIC, "java/lang/Math", "abs", "(I)I", false);
+    CallSite virtualCall =
+        new CallSite(Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
+    CallSite interfaceCall =
+        new CallSite(Opcodes.INVOKEINTERFACE, "java/util/List", "size", "()I", true);
+    CallSite specialCall =
+        new CallSite(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
 
     assertThat(staticCall.isStatic()).isTrue();
     assertThat(staticCall.isVirtual()).isFalse();
@@ -39,12 +41,13 @@ class CallSiteTest {
   }
 
   /**
-   * Unit test: Tests CallSite toMethodSignature conversion.
-   * Expects correct MethodSignature with same owner, name, and descriptor.
+   * Unit test: Tests CallSite toMethodSignature conversion. Expects correct MethodSignature with
+   * same owner, name, and descriptor.
    */
   @Test
   void testToMethodSignature() {
-    CallSite callSite = new CallSite(Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
+    CallSite callSite =
+        new CallSite(Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
     MethodSignature sig = callSite.toMethodSignature();
 
     assertThat(sig.getOwner()).isEqualTo("java/lang/String");
@@ -53,12 +56,13 @@ class CallSiteTest {
   }
 
   /**
-   * Unit test: Tests CallSite toString includes opcode name.
-   * Expects string representation to contain opcode and method info.
+   * Unit test: Tests CallSite toString includes opcode name. Expects string representation to
+   * contain opcode and method info.
    */
   @Test
   void testToString() {
-    CallSite callSite = new CallSite(Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
+    CallSite callSite =
+        new CallSite(Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
     assertThat(callSite.toString()).contains("INVOKEVIRTUAL");
     assertThat(callSite.toString()).contains("java/lang/String");
     assertThat(callSite.toString()).contains("length");

--- a/src/test/java/net/cg4j/asm/ClassHierarchyTest.java
+++ b/src/test/java/net/cg4j/asm/ClassHierarchyTest.java
@@ -1,23 +1,20 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-import org.objectweb.asm.Opcodes;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Unit tests for ClassHierarchy class.
- */
+/** Unit tests for ClassHierarchy class. */
 class ClassHierarchyTest {
 
   /**
-   * Unit test: Tests ClassHierarchy subtype queries.
-   * Expects correct transitive subtype relationships.
+   * Unit test: Tests ClassHierarchy subtype queries. Expects correct transitive subtype
+   * relationships.
    */
   @Test
   void testSubtypeQueries() {
@@ -25,32 +22,54 @@ class ClassHierarchyTest {
     Set<MethodSignature> methods = new HashSet<>();
     methods.add(new MethodSignature("java/lang/Object", "toString", "()Ljava/lang/String;"));
 
-    ClassInfo objectClass = new ClassInfo("java/lang/Object", null, Collections.emptySet(),
-        methods, Opcodes.ACC_PUBLIC, ClassLoaderType.PRIMORDIAL, false);
+    ClassInfo objectClass =
+        new ClassInfo(
+            "java/lang/Object",
+            null,
+            Collections.emptySet(),
+            methods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.PRIMORDIAL,
+            false);
 
     Set<MethodSignature> parentMethods = new HashSet<>();
     parentMethods.add(new MethodSignature("com/example/Parent", "parentMethod", "()V"));
 
-    ClassInfo parentClass = new ClassInfo("com/example/Parent", "java/lang/Object",
-        Collections.emptySet(), parentMethods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo parentClass =
+        new ClassInfo(
+            "com/example/Parent",
+            "java/lang/Object",
+            Collections.emptySet(),
+            parentMethods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     Set<MethodSignature> childMethods = new HashSet<>();
     childMethods.add(new MethodSignature("com/example/Child", "childMethod", "()V"));
 
-    ClassInfo childClass = new ClassInfo("com/example/Child", "com/example/Parent",
-        Collections.emptySet(), childMethods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo childClass =
+        new ClassInfo(
+            "com/example/Child",
+            "com/example/Parent",
+            Collections.emptySet(),
+            childMethods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    Map<String, ClassInfo> classes = Map.of(
-        "java/lang/Object", objectClass,
-        "com/example/Parent", parentClass,
-        "com/example/Child", childClass
-    );
+    Map<String, ClassInfo> classes =
+        Map.of(
+            "java/lang/Object", objectClass,
+            "com/example/Parent", parentClass,
+            "com/example/Child", childClass);
 
     ClassHierarchy hierarchy = new ClassHierarchy(classes);
 
     // Test subtype queries
     Set<String> objectSubtypes = hierarchy.getAllSubtypes("java/lang/Object");
-    assertThat(objectSubtypes).contains("java/lang/Object", "com/example/Parent", "com/example/Child");
+    assertThat(objectSubtypes)
+        .contains("java/lang/Object", "com/example/Parent", "com/example/Child");
 
     Set<String> parentSubtypes = hierarchy.getAllSubtypes("com/example/Parent");
     assertThat(parentSubtypes).contains("com/example/Parent", "com/example/Child");
@@ -61,32 +80,47 @@ class ClassHierarchyTest {
   }
 
   /**
-   * Unit test: Tests ClassHierarchy method lookup with inheritance.
-   * Expects methods to be found in parent classes.
+   * Unit test: Tests ClassHierarchy method lookup with inheritance. Expects methods to be found in
+   * parent classes.
    */
   @Test
   void testMethodLookup() {
     Set<MethodSignature> objectMethods = new HashSet<>();
     objectMethods.add(new MethodSignature("java/lang/Object", "toString", "()Ljava/lang/String;"));
 
-    ClassInfo objectClass = new ClassInfo("java/lang/Object", null, Collections.emptySet(),
-        objectMethods, Opcodes.ACC_PUBLIC, ClassLoaderType.PRIMORDIAL, false);
+    ClassInfo objectClass =
+        new ClassInfo(
+            "java/lang/Object",
+            null,
+            Collections.emptySet(),
+            objectMethods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.PRIMORDIAL,
+            false);
 
     Set<MethodSignature> childMethods = new HashSet<>();
     childMethods.add(new MethodSignature("com/example/Child", "myMethod", "()V"));
 
-    ClassInfo childClass = new ClassInfo("com/example/Child", "java/lang/Object",
-        Collections.emptySet(), childMethods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo childClass =
+        new ClassInfo(
+            "com/example/Child",
+            "java/lang/Object",
+            Collections.emptySet(),
+            childMethods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    Map<String, ClassInfo> classes = Map.of(
-        "java/lang/Object", objectClass,
-        "com/example/Child", childClass
-    );
+    Map<String, ClassInfo> classes =
+        Map.of(
+            "java/lang/Object", objectClass,
+            "com/example/Child", childClass);
 
     ClassHierarchy hierarchy = new ClassHierarchy(classes);
 
     // Child should find inherited method
-    MethodSignature inherited = hierarchy.lookupMethod("com/example/Child", "toString", "()Ljava/lang/String;");
+    MethodSignature inherited =
+        hierarchy.lookupMethod("com/example/Child", "toString", "()Ljava/lang/String;");
     assertThat(inherited).isNotNull();
     assertThat(inherited.getOwner()).isEqualTo("java/lang/Object");
 
@@ -97,34 +131,55 @@ class ClassHierarchyTest {
   }
 
   /**
-   * Unit test: Tests ClassHierarchy RTA virtual call resolution.
-   * Expects only instantiated types to be considered.
+   * Unit test: Tests ClassHierarchy RTA virtual call resolution. Expects only instantiated types to
+   * be considered.
    */
   @Test
   void testResolveVirtualCallRTA() {
     Set<MethodSignature> parentMethods = new HashSet<>();
     parentMethods.add(new MethodSignature("com/example/Parent", "doSomething", "()V"));
 
-    ClassInfo parentClass = new ClassInfo("com/example/Parent", "java/lang/Object",
-        Collections.emptySet(), parentMethods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo parentClass =
+        new ClassInfo(
+            "com/example/Parent",
+            "java/lang/Object",
+            Collections.emptySet(),
+            parentMethods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     Set<MethodSignature> child1Methods = new HashSet<>();
     child1Methods.add(new MethodSignature("com/example/Child1", "doSomething", "()V"));
 
-    ClassInfo child1Class = new ClassInfo("com/example/Child1", "com/example/Parent",
-        Collections.emptySet(), child1Methods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo child1Class =
+        new ClassInfo(
+            "com/example/Child1",
+            "com/example/Parent",
+            Collections.emptySet(),
+            child1Methods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     Set<MethodSignature> child2Methods = new HashSet<>();
     // Child2 inherits doSomething from Parent
 
-    ClassInfo child2Class = new ClassInfo("com/example/Child2", "com/example/Parent",
-        Collections.emptySet(), child2Methods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo child2Class =
+        new ClassInfo(
+            "com/example/Child2",
+            "com/example/Parent",
+            Collections.emptySet(),
+            child2Methods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    Map<String, ClassInfo> classes = Map.of(
-        "com/example/Parent", parentClass,
-        "com/example/Child1", child1Class,
-        "com/example/Child2", child2Class
-    );
+    Map<String, ClassInfo> classes =
+        Map.of(
+            "com/example/Parent", parentClass,
+            "com/example/Child1", child1Class,
+            "com/example/Child2", child2Class);
 
     ClassHierarchy hierarchy = new ClassHierarchy(classes);
 
@@ -132,27 +187,36 @@ class ClassHierarchyTest {
     Set<String> instantiatedTypes = Set.of("com/example/Child1");
 
     // RTA should only find Child1.doSomething
-    Set<MethodSignature> rtaTargets = hierarchy.resolveVirtualCallRTA(
-        "com/example/Parent", "doSomething", "()V", instantiatedTypes);
+    Set<MethodSignature> rtaTargets =
+        hierarchy.resolveVirtualCallRTA(
+            "com/example/Parent", "doSomething", "()V", instantiatedTypes);
 
     assertThat(rtaTargets).hasSize(1);
     assertThat(rtaTargets).anyMatch(m -> m.getOwner().equals("com/example/Child1"));
   }
 
   /**
-   * Unit test: Tests ClassHierarchy resolveCallSiteRTA method.
-   * Expects static calls to resolve regardless of instantiation and virtual calls to respect instantiation.
+   * Unit test: Tests ClassHierarchy resolveCallSiteRTA method. Expects static calls to resolve
+   * regardless of instantiation and virtual calls to respect instantiation.
    */
   @Test
   void testResolveCallSiteRTA() {
     Set<MethodSignature> methods = new HashSet<>();
-    methods.add(new MethodSignature("com/example/MyClass", "staticMethod", "()V",
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC));
-    methods.add(new MethodSignature("com/example/MyClass", "instanceMethod", "()V",
-        Opcodes.ACC_PUBLIC));
+    methods.add(
+        new MethodSignature(
+            "com/example/MyClass", "staticMethod", "()V", Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC));
+    methods.add(
+        new MethodSignature("com/example/MyClass", "instanceMethod", "()V", Opcodes.ACC_PUBLIC));
 
-    ClassInfo myClass = new ClassInfo("com/example/MyClass", "java/lang/Object",
-        Collections.emptySet(), methods, Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo myClass =
+        new ClassInfo(
+            "com/example/MyClass",
+            "java/lang/Object",
+            Collections.emptySet(),
+            methods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     Map<String, ClassInfo> classes = Map.of("com/example/MyClass", myClass);
     ClassHierarchy hierarchy = new ClassHierarchy(classes);
@@ -160,15 +224,16 @@ class ClassHierarchyTest {
     Set<String> instantiatedTypes = Set.of("com/example/MyClass");
 
     // Static call should resolve regardless of instantiation
-    CallSite staticCall = new CallSite(Opcodes.INVOKESTATIC, "com/example/MyClass",
-        "staticMethod", "()V", false);
+    CallSite staticCall =
+        new CallSite(Opcodes.INVOKESTATIC, "com/example/MyClass", "staticMethod", "()V", false);
     Set<MethodSignature> staticTargets = hierarchy.resolveCallSiteRTA(staticCall, Set.of());
     assertThat(staticTargets).hasSize(1);
 
     // Virtual call should respect instantiated types
-    CallSite virtualCall = new CallSite(Opcodes.INVOKEVIRTUAL, "com/example/MyClass",
-        "instanceMethod", "()V", false);
-    Set<MethodSignature> virtualTargets = hierarchy.resolveCallSiteRTA(virtualCall, instantiatedTypes);
+    CallSite virtualCall =
+        new CallSite(Opcodes.INVOKEVIRTUAL, "com/example/MyClass", "instanceMethod", "()V", false);
+    Set<MethodSignature> virtualTargets =
+        hierarchy.resolveCallSiteRTA(virtualCall, instantiatedTypes);
     assertThat(virtualTargets).hasSize(1);
 
     // Virtual call with empty instantiated types should return empty
@@ -177,28 +242,42 @@ class ClassHierarchyTest {
   }
 
   /**
-   * Unit test: Tests registering a synthetic lambda class into the hierarchy.
-   * Expects the class to appear in lookups, subclass maps, and implementor maps.
+   * Unit test: Tests registering a synthetic lambda class into the hierarchy. Expects the class to
+   * appear in lookups, subclass maps, and implementor maps.
    */
   @Test
   void testRegisterSyntheticClass() {
     // Build hierarchy with an interface
-    ClassInfo objectClass = new ClassInfo("java/lang/Object", null, Collections.emptySet(),
-        Collections.emptySet(), Opcodes.ACC_PUBLIC, ClassLoaderType.PRIMORDIAL, false);
+    ClassInfo objectClass =
+        new ClassInfo(
+            "java/lang/Object",
+            null,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.PRIMORDIAL,
+            false);
 
     Set<MethodSignature> ifaceMethods = new HashSet<>();
-    ifaceMethods.add(new MethodSignature("com/example/MyInterface", "doIt", "()V",
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT));
+    ifaceMethods.add(
+        new MethodSignature(
+            "com/example/MyInterface", "doIt", "()V", Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT));
 
-    ClassInfo ifaceClass = new ClassInfo("com/example/MyInterface", "java/lang/Object",
-        Collections.emptySet(), ifaceMethods,
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION, false);
+    ClassInfo ifaceClass =
+        new ClassInfo(
+            "com/example/MyInterface",
+            "java/lang/Object",
+            Collections.emptySet(),
+            ifaceMethods,
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    Map<String, ClassInfo> classes = new java.util.HashMap<>(Map.of(
-        "java/lang/Object", objectClass,
-        "com/example/MyInterface", ifaceClass
-    ));
+    Map<String, ClassInfo> classes =
+        new java.util.HashMap<>(
+            Map.of(
+                "java/lang/Object", objectClass,
+                "com/example/MyInterface", ifaceClass));
 
     ClassHierarchy hierarchy = new ClassHierarchy(classes);
 
@@ -207,18 +286,17 @@ class ClassHierarchyTest {
 
     // Register a synthetic lambda class implementing the interface
     Set<MethodSignature> lambdaMethods = new HashSet<>();
-    lambdaMethods.add(new MethodSignature("wala/lambda$test$0", "doIt", "()V",
-        Opcodes.ACC_PUBLIC));
+    lambdaMethods.add(new MethodSignature("wala/lambda$test$0", "doIt", "()V", Opcodes.ACC_PUBLIC));
 
-    ClassInfo syntheticClass = new ClassInfo(
-        "wala/lambda$test$0",
-        "java/lang/Object",
-        Set.of("com/example/MyInterface"),
-        lambdaMethods,
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC,
-        ClassLoaderType.APPLICATION,
-        false
-    );
+    ClassInfo syntheticClass =
+        new ClassInfo(
+            "wala/lambda$test$0",
+            "java/lang/Object",
+            Set.of("com/example/MyInterface"),
+            lambdaMethods,
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     hierarchy.registerSyntheticClass(syntheticClass);
 
@@ -228,8 +306,7 @@ class ClassHierarchyTest {
     assertThat(hierarchy.size()).isEqualTo(3);
 
     // Verify subclass relation
-    assertThat(hierarchy.getDirectSubclasses("java/lang/Object"))
-        .contains("wala/lambda$test$0");
+    assertThat(hierarchy.getDirectSubclasses("java/lang/Object")).contains("wala/lambda$test$0");
 
     // Verify implementor relation
     assertThat(hierarchy.getDirectImplementors("com/example/MyInterface"))
@@ -246,34 +323,59 @@ class ClassHierarchyTest {
   }
 
   /**
-   * Unit test: Tests implemented interface lookups are cached and stable.
-   * Expects repeated lookups to return the same computed interface closure.
+   * Unit test: Tests implemented interface lookups are cached and stable. Expects repeated lookups
+   * to return the same computed interface closure.
    */
   @Test
   void testGetAllImplementedInterfaces_CachesTransitiveClosure() {
-    ClassInfo objectClass = new ClassInfo("java/lang/Object", null, Collections.emptySet(),
-        Collections.emptySet(), Opcodes.ACC_PUBLIC, ClassLoaderType.PRIMORDIAL, false);
+    ClassInfo objectClass =
+        new ClassInfo(
+            "java/lang/Object",
+            null,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.PRIMORDIAL,
+            false);
 
-    ClassInfo baseInterface = new ClassInfo("com/example/BaseInterface", "java/lang/Object",
-        Collections.emptySet(), Collections.emptySet(),
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION, false);
+    ClassInfo baseInterface =
+        new ClassInfo(
+            "com/example/BaseInterface",
+            "java/lang/Object",
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassInfo childInterface = new ClassInfo("com/example/ChildInterface", "java/lang/Object",
-        Set.of("com/example/BaseInterface"), Collections.emptySet(),
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION, false);
+    ClassInfo childInterface =
+        new ClassInfo(
+            "com/example/ChildInterface",
+            "java/lang/Object",
+            Set.of("com/example/BaseInterface"),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassInfo implClass = new ClassInfo("com/example/MyImpl", "java/lang/Object",
-        Set.of("com/example/ChildInterface"), Collections.emptySet(),
-        Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo implClass =
+        new ClassInfo(
+            "com/example/MyImpl",
+            "java/lang/Object",
+            Set.of("com/example/ChildInterface"),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassHierarchy hierarchy = new ClassHierarchy(new java.util.HashMap<>(Map.of(
-        "java/lang/Object", objectClass,
-        "com/example/BaseInterface", baseInterface,
-        "com/example/ChildInterface", childInterface,
-        "com/example/MyImpl", implClass
-    )));
+    ClassHierarchy hierarchy =
+        new ClassHierarchy(
+            new java.util.HashMap<>(
+                Map.of(
+                    "java/lang/Object", objectClass,
+                    "com/example/BaseInterface", baseInterface,
+                    "com/example/ChildInterface", childInterface,
+                    "com/example/MyImpl", implClass)));
 
     Set<String> firstLookup = hierarchy.getAllImplementedInterfaces("com/example/MyImpl");
     Set<String> secondLookup = hierarchy.getAllImplementedInterfaces("com/example/MyImpl");
@@ -286,42 +388,61 @@ class ClassHierarchyTest {
   }
 
   /**
-   * Unit test: Tests synthetic class registration invalidates implemented-interface cache.
-   * Expects new interface closures to become visible after adding a synthetic class.
+   * Unit test: Tests synthetic class registration invalidates implemented-interface cache. Expects
+   * new interface closures to become visible after adding a synthetic class.
    */
   @Test
   void testRegisterSyntheticClass_InvalidatesImplementedInterfacesCache() {
-    ClassInfo objectClass = new ClassInfo("java/lang/Object", null, Collections.emptySet(),
-        Collections.emptySet(), Opcodes.ACC_PUBLIC, ClassLoaderType.PRIMORDIAL, false);
+    ClassInfo objectClass =
+        new ClassInfo(
+            "java/lang/Object",
+            null,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.PRIMORDIAL,
+            false);
 
-    ClassInfo parentInterface = new ClassInfo("com/example/ParentInterface", "java/lang/Object",
-        Collections.emptySet(), Collections.emptySet(),
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION, false);
+    ClassInfo parentInterface =
+        new ClassInfo(
+            "com/example/ParentInterface",
+            "java/lang/Object",
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassInfo childInterface = new ClassInfo("com/example/ChildInterface", "java/lang/Object",
-        Set.of("com/example/ParentInterface"), Collections.emptySet(),
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION, false);
+    ClassInfo childInterface =
+        new ClassInfo(
+            "com/example/ChildInterface",
+            "java/lang/Object",
+            Set.of("com/example/ParentInterface"),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassHierarchy hierarchy = new ClassHierarchy(new java.util.HashMap<>(Map.of(
-        "java/lang/Object", objectClass,
-        "com/example/ParentInterface", parentInterface,
-        "com/example/ChildInterface", childInterface
-    )));
+    ClassHierarchy hierarchy =
+        new ClassHierarchy(
+            new java.util.HashMap<>(
+                Map.of(
+                    "java/lang/Object", objectClass,
+                    "com/example/ParentInterface", parentInterface,
+                    "com/example/ChildInterface", childInterface)));
 
     assertThat(hierarchy.getAllImplementedInterfaces("com/example/ChildInterface"))
         .containsExactly("com/example/ParentInterface");
 
-    ClassInfo syntheticClass = new ClassInfo(
-        "wala/lambda$cache$0",
-        "java/lang/Object",
-        Set.of("com/example/ChildInterface"),
-        Collections.emptySet(),
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC,
-        ClassLoaderType.APPLICATION,
-        false
-    );
+    ClassInfo syntheticClass =
+        new ClassInfo(
+            "wala/lambda$cache$0",
+            "java/lang/Object",
+            Set.of("com/example/ChildInterface"),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     hierarchy.registerSyntheticClass(syntheticClass);
 
@@ -332,32 +453,52 @@ class ClassHierarchyTest {
   }
 
   /**
-   * Unit test: Tests default interface dispatch resolution for concrete implementors.
-   * Expects the interface default method to be selected when the class does not override it.
+   * Unit test: Tests default interface dispatch resolution for concrete implementors. Expects the
+   * interface default method to be selected when the class does not override it.
    */
   @Test
   void testResolveVirtualTarget_UsesDefaultInterfaceMethod() {
-    ClassInfo objectClass = new ClassInfo("java/lang/Object", null, Collections.emptySet(),
-        Collections.emptySet(), Opcodes.ACC_PUBLIC, ClassLoaderType.PRIMORDIAL, false);
+    ClassInfo objectClass =
+        new ClassInfo(
+            "java/lang/Object",
+            null,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.PRIMORDIAL,
+            false);
 
     Set<MethodSignature> ifaceMethods = new HashSet<>();
-    ifaceMethods.add(new MethodSignature("com/example/MyInterface", "doIt", "()V",
-        Opcodes.ACC_PUBLIC));
+    ifaceMethods.add(
+        new MethodSignature("com/example/MyInterface", "doIt", "()V", Opcodes.ACC_PUBLIC));
 
-    ClassInfo ifaceClass = new ClassInfo("com/example/MyInterface", "java/lang/Object",
-        Collections.emptySet(), ifaceMethods,
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION, false);
+    ClassInfo ifaceClass =
+        new ClassInfo(
+            "com/example/MyInterface",
+            "java/lang/Object",
+            Collections.emptySet(),
+            ifaceMethods,
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassInfo implClass = new ClassInfo("com/example/MyImpl", "java/lang/Object",
-        Set.of("com/example/MyInterface"), Collections.emptySet(),
-        Opcodes.ACC_PUBLIC, ClassLoaderType.APPLICATION, false);
+    ClassInfo implClass =
+        new ClassInfo(
+            "com/example/MyImpl",
+            "java/lang/Object",
+            Set.of("com/example/MyInterface"),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
-    ClassHierarchy hierarchy = new ClassHierarchy(new java.util.HashMap<>(Map.of(
-        "java/lang/Object", objectClass,
-        "com/example/MyInterface", ifaceClass,
-        "com/example/MyImpl", implClass
-    )));
+    ClassHierarchy hierarchy =
+        new ClassHierarchy(
+            new java.util.HashMap<>(
+                Map.of(
+                    "java/lang/Object", objectClass,
+                    "com/example/MyInterface", ifaceClass,
+                    "com/example/MyImpl", implClass)));
 
     MethodSignature target = hierarchy.resolveVirtualTarget("com/example/MyImpl", "doIt", "()V");
 

--- a/src/test/java/net/cg4j/asm/ClassInfoTest.java
+++ b/src/test/java/net/cg4j/asm/ClassInfoTest.java
@@ -1,22 +1,19 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-import org.objectweb.asm.Opcodes;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Unit tests for ClassInfo class.
- */
+/** Unit tests for ClassInfo class. */
 class ClassInfoTest {
 
   /**
-   * Unit test: Tests ClassInfo properties and getters.
-   * Expects correct name, superclass, interfaces, methods, loader type, and access flags.
+   * Unit test: Tests ClassInfo properties and getters. Expects correct name, superclass,
+   * interfaces, methods, loader type, and access flags.
    */
   @Test
   void testProperties() {
@@ -27,15 +24,15 @@ class ClassInfoTest {
     methods.add(new MethodSignature("com/example/MyClass", "myMethod", "()V"));
     methods.add(new MethodSignature("com/example/MyClass", "<init>", "()V"));
 
-    ClassInfo info = new ClassInfo(
-        "com/example/MyClass",
-        "java/lang/Object",
-        interfaces,
-        methods,
-        Opcodes.ACC_PUBLIC,
-        ClassLoaderType.APPLICATION,
-        false
-    );
+    ClassInfo info =
+        new ClassInfo(
+            "com/example/MyClass",
+            "java/lang/Object",
+            interfaces,
+            methods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     assertThat(info.getName()).isEqualTo("com/example/MyClass");
     assertThat(info.getSuperName()).isEqualTo("java/lang/Object");
@@ -48,23 +45,23 @@ class ClassInfoTest {
   }
 
   /**
-   * Unit test: Tests ClassInfo method lookup.
-   * Expects hasMethod and getMethod to correctly find declared methods.
+   * Unit test: Tests ClassInfo method lookup. Expects hasMethod and getMethod to correctly find
+   * declared methods.
    */
   @Test
   void testHasMethod() {
     Set<MethodSignature> methods = new HashSet<>();
     methods.add(new MethodSignature("com/example/MyClass", "myMethod", "()V"));
 
-    ClassInfo info = new ClassInfo(
-        "com/example/MyClass",
-        "java/lang/Object",
-        Collections.emptySet(),
-        methods,
-        Opcodes.ACC_PUBLIC,
-        ClassLoaderType.APPLICATION,
-        false
-    );
+    ClassInfo info =
+        new ClassInfo(
+            "com/example/MyClass",
+            "java/lang/Object",
+            Collections.emptySet(),
+            methods,
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     assertThat(info.hasMethod("myMethod", "()V")).isTrue();
     assertThat(info.hasMethod("otherMethod", "()V")).isFalse();
@@ -73,59 +70,58 @@ class ClassInfoTest {
   }
 
   /**
-   * Unit test: Tests ClassInfo for interface class.
-   * Expects correct interface and abstract flags.
+   * Unit test: Tests ClassInfo for interface class. Expects correct interface and abstract flags.
    */
   @Test
   void testInterfaceClass() {
-    ClassInfo info = new ClassInfo(
-        "com/example/MyInterface",
-        "java/lang/Object",
-        Collections.emptySet(),
-        Collections.emptySet(),
-        Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
-        ClassLoaderType.APPLICATION,
-        false
-    );
+    ClassInfo info =
+        new ClassInfo(
+            "com/example/MyInterface",
+            "java/lang/Object",
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT,
+            ClassLoaderType.APPLICATION,
+            false);
 
     assertThat(info.isInterface()).isTrue();
     assertThat(info.isAbstract()).isTrue();
   }
 
   /**
-   * Unit test: Tests hasClinit() returns true when class has static initializer.
-   * Expects hasClinit() to return true.
+   * Unit test: Tests hasClinit() returns true when class has static initializer. Expects
+   * hasClinit() to return true.
    */
   @Test
   void testHasClinit_WhenTrue() {
-    ClassInfo info = new ClassInfo(
-        "com/example/WithClinit",
-        "java/lang/Object",
-        Collections.emptySet(),
-        Collections.emptySet(),
-        Opcodes.ACC_PUBLIC,
-        ClassLoaderType.APPLICATION,
-        true
-    );
+    ClassInfo info =
+        new ClassInfo(
+            "com/example/WithClinit",
+            "java/lang/Object",
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            true);
 
     assertThat(info.hasClinit()).isTrue();
   }
 
   /**
-   * Unit test: Tests hasClinit() returns false when class has no static initializer.
-   * Expects hasClinit() to return false.
+   * Unit test: Tests hasClinit() returns false when class has no static initializer. Expects
+   * hasClinit() to return false.
    */
   @Test
   void testHasClinit_WhenFalse() {
-    ClassInfo info = new ClassInfo(
-        "com/example/NoClinit",
-        "java/lang/Object",
-        Collections.emptySet(),
-        Collections.emptySet(),
-        Opcodes.ACC_PUBLIC,
-        ClassLoaderType.APPLICATION,
-        false
-    );
+    ClassInfo info =
+        new ClassInfo(
+            "com/example/NoClinit",
+            "java/lang/Object",
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Opcodes.ACC_PUBLIC,
+            ClassLoaderType.APPLICATION,
+            false);
 
     assertThat(info.hasClinit()).isFalse();
   }

--- a/src/test/java/net/cg4j/asm/ClassInfoVisitorTest.java
+++ b/src/test/java/net/cg4j/asm/ClassInfoVisitorTest.java
@@ -1,24 +1,22 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V11;
 
-/**
- * Unit tests for ClassInfoVisitor class.
- */
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+
+/** Unit tests for ClassInfoVisitor class. */
 class ClassInfoVisitorTest {
 
   /**
-   * Unit test: Tests that ClassInfoVisitor detects {@code <clinit>} method.
-   * Expects hasClinit() to return true when class has static initializer.
+   * Unit test: Tests that ClassInfoVisitor detects {@code <clinit>} method. Expects hasClinit() to
+   * return true when class has static initializer.
    */
   @Test
   void testDetectsClinitMethod() {
@@ -32,8 +30,8 @@ class ClassInfoVisitorTest {
   }
 
   /**
-   * Unit test: Tests that ClassInfoVisitor correctly reports no {@code <clinit>}.
-   * Expects hasClinit() to return false when class has no static initializer.
+   * Unit test: Tests that ClassInfoVisitor correctly reports no {@code <clinit>}. Expects
+   * hasClinit() to return false when class has no static initializer.
    */
   @Test
   void testNoClinitMethod() {
@@ -47,8 +45,8 @@ class ClassInfoVisitorTest {
   }
 
   /**
-   * Unit test: Tests that {@code <clinit>} with wrong descriptor is not detected.
-   * Expects hasClinit() to return false when clinit has wrong signature.
+   * Unit test: Tests that {@code <clinit>} with wrong descriptor is not detected. Expects
+   * hasClinit() to return false when clinit has wrong signature.
    */
   @Test
   void testClinitWithWrongDescriptor() {
@@ -61,9 +59,7 @@ class ClassInfoVisitorTest {
     assertThat(info.hasClinit()).isFalse();
   }
 
-  /**
-   * Creates bytecode for a class with a valid {@code <clinit>} method.
-   */
+  /** Creates bytecode for a class with a valid {@code <clinit>} method. */
   private byte[] createClassWithClinit() {
     ClassWriter cw = new ClassWriter(0);
     cw.visit(V11, ACC_PUBLIC, "com/example/WithClinit", null, "java/lang/Object", null);
@@ -78,9 +74,7 @@ class ClassInfoVisitorTest {
     return cw.toByteArray();
   }
 
-  /**
-   * Creates bytecode for a class without any {@code <clinit>} method.
-   */
+  /** Creates bytecode for a class without any {@code <clinit>} method. */
   private byte[] createClassWithoutClinit() {
     ClassWriter cw = new ClassWriter(0);
     cw.visit(V11, ACC_PUBLIC, "com/example/NoClinit", null, "java/lang/Object", null);
@@ -96,9 +90,7 @@ class ClassInfoVisitorTest {
     return cw.toByteArray();
   }
 
-  /**
-   * Creates bytecode with a method named {@code <clinit>} but with wrong descriptor.
-   */
+  /** Creates bytecode with a method named {@code <clinit>} but with wrong descriptor. */
   private byte[] createClassWithWrongClinitDescriptor() {
     ClassWriter cw = new ClassWriter(0);
     cw.visit(V11, ACC_PUBLIC, "com/example/BadClinit", null, "java/lang/Object", null);

--- a/src/test/java/net/cg4j/asm/ClassLoaderTypeTest.java
+++ b/src/test/java/net/cg4j/asm/ClassLoaderTypeTest.java
@@ -1,17 +1,14 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Unit tests for ClassLoaderType enum.
- */
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for ClassLoaderType enum. */
 class ClassLoaderTypeTest {
 
   /**
-   * Unit test: Tests ClassLoaderType enum values.
-   * Expects correct enum values and valueOf behavior.
+   * Unit test: Tests ClassLoaderType enum values. Expects correct enum values and valueOf behavior.
    */
   @Test
   void testValues() {

--- a/src/test/java/net/cg4j/asm/JdkLocatorTest.java
+++ b/src/test/java/net/cg4j/asm/JdkLocatorTest.java
@@ -1,17 +1,15 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Unit tests for JdkLocator class.
- */
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for JdkLocator class. */
 class JdkLocatorTest {
 
   /**
-   * Unit test: Tests JdkLocator Java version detection.
-   * Expects version to be at least 11 and isJava9OrLater to return true.
+   * Unit test: Tests JdkLocator Java version detection. Expects version to be at least 11 and
+   * isJava9OrLater to return true.
    */
   @Test
   void testJavaVersion() {

--- a/src/test/java/net/cg4j/asm/LambdaCallSiteTest.java
+++ b/src/test/java/net/cg4j/asm/LambdaCallSiteTest.java
@@ -1,30 +1,28 @@
 package net.cg4j.asm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Unit tests for LambdaCallSite class.
- */
+/** Unit tests for LambdaCallSite class. */
 class LambdaCallSiteTest {
 
   /**
-   * Unit test: Tests constructor and all getter methods.
-   * Expects all fields to be returned correctly.
+   * Unit test: Tests constructor and all getter methods. Expects all fields to be returned
+   * correctly.
    */
   @Test
   void testConstructorAndGetters() {
-    LambdaCallSite site = new LambdaCallSite(
-        "invoke",
-        "(Ljava/lang/Object;)Ljava/lang/Object;",
-        "()Lkotlin/jvm/functions/Function1;",
-        "com/example/MyClass",
-        "lambda$method$0",
-        "(Ljava/lang/String;)Ljava/lang/String;",
-        Opcodes.H_INVOKESTATIC
-    );
+    LambdaCallSite site =
+        new LambdaCallSite(
+            "invoke",
+            "(Ljava/lang/Object;)Ljava/lang/Object;",
+            "()Lkotlin/jvm/functions/Function1;",
+            "com/example/MyClass",
+            "lambda$method$0",
+            "(Ljava/lang/String;)Ljava/lang/String;",
+            Opcodes.H_INVOKESTATIC);
 
     assertThat(site.getSamMethodName()).isEqualTo("invoke");
     assertThat(site.getSamDescriptor()).isEqualTo("(Ljava/lang/Object;)Ljava/lang/Object;");
@@ -36,20 +34,20 @@ class LambdaCallSiteTest {
   }
 
   /**
-   * Unit test: Tests toString format includes SAM and impl information.
-   * Expects a readable string with both SAM and impl details.
+   * Unit test: Tests toString format includes SAM and impl information. Expects a readable string
+   * with both SAM and impl details.
    */
   @Test
   void testToString() {
-    LambdaCallSite site = new LambdaCallSite(
-        "run",
-        "()V",
-        "()Ljava/lang/Runnable;",
-        "com/example/Foo",
-        "lambda$bar$0",
-        "()V",
-        Opcodes.H_INVOKESTATIC
-    );
+    LambdaCallSite site =
+        new LambdaCallSite(
+            "run",
+            "()V",
+            "()Ljava/lang/Runnable;",
+            "com/example/Foo",
+            "lambda$bar$0",
+            "()V",
+            Opcodes.H_INVOKESTATIC);
 
     String result = site.toString();
     assertThat(result).contains("run");

--- a/src/test/java/net/cg4j/asm/MethodSignatureTest.java
+++ b/src/test/java/net/cg4j/asm/MethodSignatureTest.java
@@ -1,18 +1,16 @@
 package net.cg4j.asm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Unit tests for MethodSignature class.
- */
+/** Unit tests for MethodSignature class. */
 class MethodSignatureTest {
 
   /**
-   * Unit test: Tests MethodSignature creation and URI formatting.
-   * Expects correct getters and URI format.
+   * Unit test: Tests MethodSignature creation and URI formatting. Expects correct getters and URI
+   * format.
    */
   @Test
   void testToUri() {
@@ -26,8 +24,8 @@ class MethodSignatureTest {
   }
 
   /**
-   * Unit test: Tests MethodSignature equality and hashCode.
-   * Expects equal signatures to be equal and have same hashCode.
+   * Unit test: Tests MethodSignature equality and hashCode. Expects equal signatures to be equal
+   * and have same hashCode.
    */
   @Test
   void testEquality() {
@@ -41,21 +39,26 @@ class MethodSignatureTest {
   }
 
   /**
-   * Unit test: Tests MethodSignature access flag methods.
-   * Expects correct isPublic, isAbstract, isStatic behavior.
+   * Unit test: Tests MethodSignature access flag methods. Expects correct isPublic, isAbstract,
+   * isStatic behavior.
    */
   @Test
   void testAccessFlags() {
-    MethodSignature publicMethod = new MethodSignature(
-        "com/example/MyClass", "publicMethod", "()V", Opcodes.ACC_PUBLIC);
-    MethodSignature privateMethod = new MethodSignature(
-        "com/example/MyClass", "privateMethod", "()V", Opcodes.ACC_PRIVATE);
-    MethodSignature abstractMethod = new MethodSignature(
-        "com/example/MyClass", "abstractMethod", "()V", Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT);
-    MethodSignature staticMethod = new MethodSignature(
-        "com/example/MyClass", "staticMethod", "()V", Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-    MethodSignature noFlagsMethod = new MethodSignature(
-        "com/example/MyClass", "packageMethod", "()V");
+    MethodSignature publicMethod =
+        new MethodSignature("com/example/MyClass", "publicMethod", "()V", Opcodes.ACC_PUBLIC);
+    MethodSignature privateMethod =
+        new MethodSignature("com/example/MyClass", "privateMethod", "()V", Opcodes.ACC_PRIVATE);
+    MethodSignature abstractMethod =
+        new MethodSignature(
+            "com/example/MyClass",
+            "abstractMethod",
+            "()V",
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT);
+    MethodSignature staticMethod =
+        new MethodSignature(
+            "com/example/MyClass", "staticMethod", "()V", Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+    MethodSignature noFlagsMethod =
+        new MethodSignature("com/example/MyClass", "packageMethod", "()V");
 
     assertThat(publicMethod.isPublic()).isTrue();
     assertThat(publicMethod.isAbstract()).isFalse();
@@ -77,8 +80,8 @@ class MethodSignatureTest {
   }
 
   /**
-   * Unit test: Tests boot method URI format matches WALA's convention.
-   * Expects synthetic boot method to return just "&lt;boot&gt;" instead of full URI.
+   * Unit test: Tests boot method URI format matches WALA's convention. Expects synthetic boot
+   * method to return just "&lt;boot&gt;" instead of full URI.
    */
   @Test
   void testBootMethodUri_MatchesWalaConvention() {

--- a/src/test/java/net/cg4j/asm/ScopeExclusionsTest.java
+++ b/src/test/java/net/cg4j/asm/ScopeExclusionsTest.java
@@ -1,8 +1,7 @@
 package net.cg4j.asm;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.objectweb.asm.Opcodes;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,18 +12,16 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.objectweb.asm.Opcodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-/**
- * Unit tests for ScopeExclusions class.
- */
+/** Unit tests for ScopeExclusions class. */
 class ScopeExclusionsTest {
 
   /**
-   * Unit test: Loads default exclusion patterns from the built-in resource.
-   * Expects at least one pattern loaded.
+   * Unit test: Loads default exclusion patterns from the built-in resource. Expects at least one
+   * pattern loaded.
    */
   @Test
   void testLoadDefaults_HasPatterns() throws IOException {
@@ -34,8 +31,8 @@ class ScopeExclusionsTest {
   }
 
   /**
-   * Unit test: Tests that default exclusions match expected JDK packages.
-   * Expects java/util, javax, sun packages to be excluded; java/lang to be kept.
+   * Unit test: Tests that default exclusions match expected JDK packages. Expects java/util, javax,
+   * sun packages to be excluded; java/lang to be kept.
    */
   @Test
   void testIsExcluded_MatchesExpectedPatterns() throws IOException {
@@ -60,8 +57,8 @@ class ScopeExclusionsTest {
   }
 
   /**
-   * Unit test: Verifies applyExclusions only removes Primordial classes.
-   * Expects Application classes matching exclusion patterns to be preserved.
+   * Unit test: Verifies applyExclusions only removes Primordial classes. Expects Application
+   * classes matching exclusion patterns to be preserved.
    */
   @Test
   void testApplyExclusions_OnlyRemovesPrimordial() throws IOException {
@@ -70,16 +67,16 @@ class ScopeExclusionsTest {
     Map<String, ClassInfo> classes = new HashMap<>();
 
     // Primordial class matching exclusion -> should be removed
-    classes.put("java/util/HashMap", makeClassInfo(
-        "java/util/HashMap", ClassLoaderType.PRIMORDIAL));
+    classes.put(
+        "java/util/HashMap", makeClassInfo("java/util/HashMap", ClassLoaderType.PRIMORDIAL));
 
     // Application class matching exclusion pattern -> should be preserved
-    classes.put("java/util/CustomAppUtil", makeClassInfo(
-        "java/util/CustomAppUtil", ClassLoaderType.APPLICATION));
+    classes.put(
+        "java/util/CustomAppUtil",
+        makeClassInfo("java/util/CustomAppUtil", ClassLoaderType.APPLICATION));
 
     // Primordial class NOT matching exclusion -> should be preserved
-    classes.put("java/lang/Object", makeClassInfo(
-        "java/lang/Object", ClassLoaderType.PRIMORDIAL));
+    classes.put("java/lang/Object", makeClassInfo("java/lang/Object", ClassLoaderType.PRIMORDIAL));
 
     Map<String, ClassInfo> filtered = exclusions.applyExclusions(classes);
 
@@ -90,20 +87,17 @@ class ScopeExclusionsTest {
   }
 
   /**
-   * Unit test: Verifies non-matching Primordial classes are preserved.
-   * Expects java/lang/* classes to remain after applying default exclusions.
+   * Unit test: Verifies non-matching Primordial classes are preserved. Expects java/lang/* classes
+   * to remain after applying default exclusions.
    */
   @Test
   void testApplyExclusions_PreservesNonMatchingPrimordial() throws IOException {
     ScopeExclusions exclusions = ScopeExclusions.loadDefaults();
 
     Map<String, ClassInfo> classes = new HashMap<>();
-    classes.put("java/lang/Object", makeClassInfo(
-        "java/lang/Object", ClassLoaderType.PRIMORDIAL));
-    classes.put("java/lang/String", makeClassInfo(
-        "java/lang/String", ClassLoaderType.PRIMORDIAL));
-    classes.put("java/lang/Enum", makeClassInfo(
-        "java/lang/Enum", ClassLoaderType.PRIMORDIAL));
+    classes.put("java/lang/Object", makeClassInfo("java/lang/Object", ClassLoaderType.PRIMORDIAL));
+    classes.put("java/lang/String", makeClassInfo("java/lang/String", ClassLoaderType.PRIMORDIAL));
+    classes.put("java/lang/Enum", makeClassInfo("java/lang/Enum", ClassLoaderType.PRIMORDIAL));
 
     Map<String, ClassInfo> filtered = exclusions.applyExclusions(classes);
 
@@ -114,8 +108,8 @@ class ScopeExclusionsTest {
   }
 
   /**
-   * Unit test: Verifies ScopeExclusions.none() excludes nothing.
-   * Expects all classes to be preserved regardless of loader type.
+   * Unit test: Verifies ScopeExclusions.none() excludes nothing. Expects all classes to be
+   * preserved regardless of loader type.
    */
   @Test
   void testNone_ExcludesNothing() {
@@ -125,28 +119,24 @@ class ScopeExclusionsTest {
     assertThat(exclusions.isExcluded("java/util/HashMap")).isFalse();
 
     Map<String, ClassInfo> classes = new HashMap<>();
-    classes.put("java/util/HashMap", makeClassInfo(
-        "java/util/HashMap", ClassLoaderType.PRIMORDIAL));
-    classes.put("com/example/MyClass", makeClassInfo(
-        "com/example/MyClass", ClassLoaderType.APPLICATION));
+    classes.put(
+        "java/util/HashMap", makeClassInfo("java/util/HashMap", ClassLoaderType.PRIMORDIAL));
+    classes.put(
+        "com/example/MyClass", makeClassInfo("com/example/MyClass", ClassLoaderType.APPLICATION));
 
     Map<String, ClassInfo> filtered = exclusions.applyExclusions(classes);
     assertThat(filtered).hasSize(2);
   }
 
   /**
-   * Unit test: Loads exclusion patterns from a custom file.
-   * Expects custom patterns to work correctly.
+   * Unit test: Loads exclusion patterns from a custom file. Expects custom patterns to work
+   * correctly.
    */
   @Test
   void testLoadFromFile_CustomPatterns(@TempDir Path tempDir) throws IOException {
     Path customFile = tempDir.resolve("custom-exclusions.txt");
-    Files.write(customFile, List.of(
-        "# Custom exclusions",
-        "com/example/internal/.*",
-        "",
-        "org/test/.*"
-    ));
+    Files.write(
+        customFile, List.of("# Custom exclusions", "com/example/internal/.*", "", "org/test/.*"));
 
     ScopeExclusions exclusions = ScopeExclusions.loadFromFile(customFile.toFile());
 
@@ -158,8 +148,8 @@ class ScopeExclusionsTest {
   }
 
   /**
-   * Unit test: Tests error handling for non-existent exclusion file.
-   * Expects IOException with descriptive message.
+   * Unit test: Tests error handling for non-existent exclusion file. Expects IOException with
+   * descriptive message.
    */
   @Test
   void testLoadFromFile_NonExistent() {
@@ -171,27 +161,28 @@ class ScopeExclusionsTest {
   }
 
   /**
-   * Unit test: Tests error handling for invalid regex in exclusion file.
-   * Expects IllegalArgumentException with line number context.
+   * Unit test: Tests error handling for invalid regex in exclusion file. Expects
+   * IllegalArgumentException with line number context.
    */
   @Test
   void testLoadFromFile_InvalidRegex(@TempDir Path tempDir) throws IOException {
     Path badFile = tempDir.resolve("bad-exclusions.txt");
-    Files.write(badFile, List.of(
-        "valid/pattern/.*",
-        "[invalid regex"
-    ));
+    Files.write(badFile, List.of("valid/pattern/.*", "[invalid regex"));
 
     assertThatThrownBy(() -> ScopeExclusions.loadFromFile(badFile.toFile()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("line 2");
   }
 
-  /**
-   * Creates a minimal ClassInfo for testing.
-   */
+  /** Creates a minimal ClassInfo for testing. */
   private static ClassInfo makeClassInfo(String name, ClassLoaderType loaderType) {
-    return new ClassInfo(name, "java/lang/Object", Collections.emptySet(),
-        new HashSet<>(), Opcodes.ACC_PUBLIC, loaderType, false);
+    return new ClassInfo(
+        name,
+        "java/lang/Object",
+        Collections.emptySet(),
+        new HashSet<>(),
+        Opcodes.ACC_PUBLIC,
+        loaderType,
+        false);
   }
 }


### PR DESCRIPTION
## Summary
This adds a repository-wide Google Java formatting workflow using Spotless across local hooks and GitHub Actions. It reformats the existing Java sources and tests, and it now gates CI compile and test jobs on the same pre-commit formatting check.

## Changes
- add `spotless-maven-plugin` 3.4.0 with Google Java Format in `pom.xml`
- add a local `.pre-commit-config.yaml` hook that runs `mvn spotless:check`
- reformat the current Java source and test tree with `mvn spotless:apply`
- document the formatting and pre-commit workflow in `README.md`
- align `AGENTS.md` style guidance with Spotless-managed formatting
- add a GitHub Actions `pre-commit` job so formatting checks run before compile and test